### PR TITLE
build: support Go 1.17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,21 +9,17 @@ on:
      - master
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: ^1.17
       id: go
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-
     - name: Style
       run: make style
     - name: Vet

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,6 @@
 go:
     cgo: false
-    version: 1.16
+    version: 1.17
 repository:
     path: github.com/burningalchemist/sql_exporter
 build:

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ docker:
 promu:
 	@GOOS=$(shell uname -s | tr A-Z a-z) \
 		GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
-		$(GO) get -u github.com/prometheus/promu
+		$(GO) install github.com/prometheus/promu@v0.12.0
 
 
 .PHONY: all style format build test vet tarball docker promu


### PR DESCRIPTION
- promu.yml: Update Promu configuration to use Go v1.17 for builds;
- Makefile: Fix `go get` deprecation warning when installing `promu`, which is outside of the main module. Use `go install github.com/prometheus/promu@v0.12.0` with a pinned version instead.