### PR TITLE
build: use distroless static base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,10 @@ WORKDIR /go/src/github.com/burningalchemist/sql_exporter
 RUN make
 
 # Make image and copy build sql_exporter
-FROM        quay.io/prometheus/busybox:glibc
+FROM        gcr.io/distroless/static:nonroot
 MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
 COPY        --from=builder /go/src/github.com/burningalchemist/sql_exporter/sql_exporter  /bin/sql_exporter
 
+USER        65534
 EXPOSE      9399
 ENTRYPOINT  [ "/bin/sql_exporter" ]


### PR DESCRIPTION
It is a common practise to use distroless/static images
for Go executables, especially if CGO is disabled

On the other hand, using distroless/static image reduces
the final image size and attack surface

EDIT:
The current image `quay.io/prometheus/busybox:glibc` runs as root.

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>