### PR TITLE
build: update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG  ARCH="amd64"
+ARG  OS="linux"
 FROM quay.io/prometheus/golang-builder AS builder
 
 # Get sql_exporter
@@ -8,9 +10,10 @@ WORKDIR /go/src/github.com/burningalchemist/sql_exporter
 RUN make
 
 # Make image and copy build sql_exporter
-FROM        quay.io/prometheus/busybox:glibc
-MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
+FROM        quay.io/prometheus/busybox-${OS}-${ARCH}:latest
+LABEL       maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 COPY        --from=builder /go/src/github.com/burningalchemist/sql_exporter/sql_exporter  /bin/sql_exporter
 
 EXPOSE      9399
+USER        nobody
 ENTRYPOINT  [ "/bin/sql_exporter" ]


### PR DESCRIPTION
Update Dockerfile to stay compliant with Prometheus community decisions, like:
- use a minimal busybox image (comes with `uclibc`);
- run as `nobody` user;
- minor changes to MAINTANER/LABEL statement.