### PR TITLE
Adds a user/group + chown to make it easier to mount configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,13 @@ FROM        quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 LABEL       maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 COPY        --from=builder /go/src/github.com/burningalchemist/sql_exporter/sql_exporter  /bin/sql_exporter
 
+# Create user and group
+RUN addgroup sql_exporter && \
+    adduser -G sql_exporter -D sql_exporter && \
+    mkdir -p /var/lib/sql_exporter && \
+    chown -R sql_exporter:sql_exporter /var/lib/sql_exporter
+
 EXPOSE      9399
-USER        nobody
+USER        sql_exporter
+WORKDIR     /var/lib/sql_exporter
 ENTRYPOINT  [ "/bin/sql_exporter" ]


### PR DESCRIPTION
With the `nobody` user, it's not straightforward to find a place to mount your `sql_exporter.yml` config.  These changes explicitly add a new user and chown a directory that allows the user to run something like this:

`docker run -p 9399:9399 -v /my/local/configs:/var/lib/sql_exporter burningalchemist/sql_exporter ...`