### PR TITLE
chore: add darwin/arm64 arch to promu

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -27,3 +27,4 @@ crossbuild:
         - windows/amd64
         - linux/armv7
         - linux/arm64
+        - darwin/arm64


### PR DESCRIPTION
Promu: create builds for Apple M1 Silicon