### PR TITLE
feat: add globbing support to collector refs in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,17 @@ target:
   data_source_name: 'sqlserver://prom_user:prom_password@dbserver1.example.com:1433'
 
   # Collectors (referenced by name) to execute on the target.
-  collectors: [pricing_data_freshness]
+  # Glob patterns are supported (see <https://pkg.go.dev/path/filepath#Match> for syntax).
+  collectors: [pricing_data_freshness, pricing_*]
 
 # Collector definition files.
+# Glob patterns are supported (see <https://pkg.go.dev/path/filepath#Match> for syntax).
 collector_files:
   - "*.collector.yml"
 ```
+
+**NOTE:** The `collectors` and `collector_files` configurations support [Glob pattern matching](https://pkg.go.dev/path/filepath#Match).
+To match names with literal pattern terms in them, e.g. `collector_*1*`, these must be escaped: `collector_\*1\*`.
 
 ### Collectors
 

--- a/examples/sql_exporter.yml
+++ b/examples/sql_exporter.yml
@@ -21,8 +21,10 @@ target:
   data_source_name: 'sqlserver://prom_user:prom_password@dbserver1.example.com:1433'
 
   # Collectors (referenced by name) to execute on the target.
-  collectors: [mssql_standard]
+  # Glob patterns are supported (see <https://pkg.go.dev/path/filepath#Match> for syntax).
+  collectors: [mssql_*]
 
 # Collector files specifies a list of globs. One collector definition is read from each matching file.
+# Glob patterns are supported (see <https://pkg.go.dev/path/filepath#Match> for syntax).
 collector_files: 
   - "*.collector.yml"


### PR DESCRIPTION
This PR implements support for glob patterns (see linked issue) in the `collectors` configuration of `target` (and `jobs`).

This change is _almost_ non-breaking because glob patterns without matching terms act as exact string matchers, i.e. the previous behaviour for the `collectors` configuration. However, the catch is that users using matching terms, e.g. `*`, `?`, `[`, `]` or `^`, in their collector names (a very unlikely but possible case) must now escape those characters.

The implementation is not _perfectly_ efficient as it adds an inner `for`-loop and uses a `map` during collector resolving to ensure that collectors matching multiple patterns are only added once to the output `resolved` array. However, I don't think this is a big issue in practice. In any case let me know if you have any feedback.

Resolves #184 