### PR TITLE
fix: don't fail immediately in resolveCollectorRefs nested loop

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -566,7 +566,7 @@ func resolveCollectorRefs(
 				return nil, fmt.Errorf("bad collector %q referenced in %s: %w", cref, ctx, err)
 			}
 			if !matched {
-				return nil, fmt.Errorf("unknown collector %q referenced in %s", cref, ctx)
+				continue
 			}
 			found[c] = true
 		}
@@ -574,6 +574,9 @@ func resolveCollectorRefs(
 	resolved := make([]*CollectorConfig, 0, len(found))
 	for k := range found {
 		resolved = append(resolved, k)
+	}
+	if len(resolved) == 0 {
+		return nil, fmt.Errorf("no matching collectors referenced in %s", ctx)
 	}
 	return resolved, nil
 }


### PR DESCRIPTION
This PR fixes a bug when `resolveCollectorRefs()` fails immediately in nested loop

https://github.com/burningalchemist/sql_exporter/blob/dbe888fa8fda330f18732387a99a99057d0b8e06/config/config.go?plain=1#L562-L573

Which actually happens every time there is a name mismatch in the slice and the map. For example, we have 3 collector files:

```
vertica_eon.collector.yml
vertica_ops.collector.yml
vertica_platform.collector.yml
```

And the following `sql_exporter.yml` with collectors specified without globbing

```
target:
  collectors:
    - vertica_ops
    - vertica_platform

collector_files:
  - '*.collector.yml'
 ```

In the inner loop, the function will compare `vertica_ops` against all collector names in the map and return an error when it hits either `vertica_eon` or `vertica_platform`, which is an unexpected behavior. The function should continue instead and return an error only if there are no matching collectors.