### PR TITLE
add unit tests and minor fixes for `resolveCollectorRefs()`

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolveCollectorRefs(t *testing.T) {
+	colls := map[string]*CollectorConfig{
+		"a":  &CollectorConfig{Name: "a"},
+		"b":  &CollectorConfig{Name: "b"},
+		"c":  &CollectorConfig{Name: "b"},
+		"aa": &CollectorConfig{Name: "aa"},
+	}
+
+	t.Run("NoGlobbing", func(t *testing.T) {
+		crefs := []string{
+			"a",
+			"b",
+		}
+		cs, err := resolveCollectorRefs(crefs, colls, "target")
+		if err != nil {
+			t.Fatalf("expected no error but got: %v", err)
+		}
+		if len(cs) != 2 {
+			t.Fatalf("expected len(cs)=2 but got len(cs)=%d", len(cs))
+		}
+		expected := []*CollectorConfig{
+			colls["a"],
+			colls["b"],
+		}
+		if !reflect.DeepEqual(cs, expected) {
+			t.Fatalf("expected cs=%v but got cs=%v", expected, cs)
+		}
+	})
+
+	t.Run("Globbing", func(t *testing.T) {
+		crefs := []string{
+			"a*",
+			"b",
+		}
+		cs, err := resolveCollectorRefs(crefs, colls, "target")
+		if err != nil {
+			t.Fatalf("expected no error but got: %v", err)
+		}
+		if len(cs) != 3 {
+			t.Fatalf("expected len(cs)=3 but got len(cs)=%d", len(cs))
+		}
+		expected1 := []*CollectorConfig{
+			colls["a"],
+			colls["aa"],
+			colls["b"],
+		}
+		expected2 := []*CollectorConfig{ // filepath.Match() is non-deterministic
+			colls["aa"],
+			colls["a"],
+			colls["b"],
+		}
+		if !reflect.DeepEqual(cs, expected1) && !reflect.DeepEqual(cs, expected2) {
+			t.Fatalf("expected cs=%v or cs=%v but got cs=%v", expected1, expected2, cs)
+		}
+	})
+
+	t.Run("NoCollectorRefs", func(t *testing.T) {
+		crefs := []string{}
+		cs, err := resolveCollectorRefs(crefs, colls, "target")
+		if err != nil {
+			t.Fatalf("expected no error but got: %v", err)
+		}
+		if len(cs) != 0 {
+			t.Fatalf("expected len(cs)=0 but got len(cs)=%d", len(cs))
+		}
+	})
+
+	t.Run("UnknownCollector", func(t *testing.T) {
+		crefs := []string{
+			"a",
+			"x",
+		}
+		_, err := resolveCollectorRefs(crefs, colls, "target")
+		if err == nil {
+			t.Fatalf("expected error but got none")
+		}
+		// TODO: Code should use error types and check with 'errors.Is(err1, err2)'.
+		expected := "unknown collector \"x\" referenced in target"
+		if err.Error() != expected {
+			t.Fatalf("expected err=%q but got err=%q", expected, err.Error())
+		}
+	})
+}


### PR DESCRIPTION
After my shameful programming errors in PR #194, some of them reported in #210 and fixed in #208, I decided to shield the codebase a bit against this type of mistakes by adding unit tests for the `resolveCollectorRefs()` function. In particular:

* `NoGlobbing` test: checks that non-globbed collector references are correctly resolved.
* `Globbing` test: checks that globbed collector references are correctly resolved.
* `NoCollectorRefs` test: checks that `resolveCollectorRefs()` resolves to empty when no collector references are given.
* `UnknownCollector` test: checks that `resolveCollectorRefs()` errors correctly when a collector reference is invalid.

All of the above tests (with the exception of `Globbing`) pass with the implementation in `0.9.3` (before globbing support).

Only the `NoCollectorRefs` test passes with the implementation in `0.10.0` (after globbing support => apologies again!).

The `NoCollectorRefs` and `UnknownCollector` tests do not pass with the implementation in `master` (after the fix in #208). The `NoGlobbing` test passes/fails in a non-deterministic manner because `resolveCollectorRefs()` no longer returns the resolved collectors in the same order as in `0.9.3`. Note that order does not really matter, but still wanted to stay correct.

All of the above is now also fixed in a second commit in this PR, bringing `resolveCollectorRefs()` to its previous behaviour when not using globbing patterns in collector references:
* return non-globbed resolved collectors in the order they are found
* do not error when no collectors are resolved

The `Makefile` and the GitHub `build.yml` workflow in the project already have testing support, so all of this will be automatically executed in future PRs/commits. For example:

Local machine:
```
$ make test
>> running tests
?       github.com/burningalchemist/sql_exporter        [no test files]
?       github.com/burningalchemist/sql_exporter/cmd/sql_exporter       [no test files]
?       github.com/burningalchemist/sql_exporter/errors [no test files]
ok      github.com/burningalchemist/sql_exporter/config 0.036s
```

GitHub workflow:
![image](https://user-images.githubusercontent.com/5802993/232258717-3bc73ef1-a68e-4358-ad72-654416ed21c7.png)

I hope this helps to avoid these silly mistakes in future contributions :)

--

fixes #210 