### PR TITLE
build: containers via multi-platform Dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,13 +52,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v3
-        with:
-          go-version: ^1.18
-
       - name: Check out the repo
         uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -82,6 +80,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          file: Dockerfile.multi-arch
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.multi-arch
+++ b/Dockerfile.multi-arch
@@ -1,0 +1,20 @@
+FROM --platform=$BUILDPLATFORM quay.io/prometheus/golang-builder AS builder
+
+# Get sql_exporter
+ADD .   /go/src/github.com/burningalchemist/sql_exporter
+WORKDIR /go/src/github.com/burningalchemist/sql_exporter
+
+# Do makefile
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH make
+
+# Make image and copy build sql_exporter
+FROM  --platform=$TARGETPLATFORM quay.io/prometheus/busybox:latest
+LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
+COPY  --from=builder /go/src/github.com/burningalchemist/sql_exporter/sql_exporter  /bin/sql_exporter
+
+EXPOSE      9399
+USER        nobody
+ENTRYPOINT  [ "/bin/sql_exporter" ]

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ style:
 
 test:
 	@echo ">> running tests"
-	@$(GO) test -short -race $(pkgs)
+	@$(GO) test -short $(pkgs)
 
 format:
 	@echo ">> formatting code"


### PR DESCRIPTION
## Notable changes

As there's a demand to have arm64 images in #218, we need to:

- provide platform list when building with `docker buildx build --platform=...`
- cross-compile the application to run on a respective platform

This PR introduces `Dockerfile.multi-arch` along with the updated Github Actions workflow to produce and push images for `linux/amd64` and `linux/arm64` (and potentially, other platforms too). We also keep original `Dockerfile` for compatibility and regular scenarios.

In addition, we need to use `docker/setup-qemu-action@v2` step to address multi-arch build issues and emulate platforms when cross-compiling.

## References

- https://docs.docker.com/build/building/multi-platform/