### PR TITLE
fix: typo and wrong file reference for rpm

### DIFF
--- a/packaging/rpm/sql_exporter.service
+++ b/packaging/rpm/sql_exporter.service
@@ -5,7 +5,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-EnvironmentFile=/etc/default/prometheus-sql-exporter
+EnvironmentFile=/etc/sysconfig/sql_exporter
 User=sql_exporter
 Group=sql_exporter
 Type=simple
@@ -13,7 +13,7 @@ Restart=on-failure
 WorkingDirectory=/usr/share/sql_exporter
 RuntimeDirectory=sql_exporter
 RuntimeDirectoryMode=0750
-ExecStart=/usr/bin/sql_exporter -config.file=${CONF_FILE} -web.listen-address=${LISTEN_ADDRESS} -log.json=${LOG_JSON} -log-level=${LOG_LEVEL} -web.enable-reload=${ENABLE_RELOAD} -web.metrics-path=${METRICS_PATH} -web.config.file=${WEB_CONFIG_FILE}
+ExecStart=/usr/bin/sql_exporter -config.file=${CONF_FILE} -web.listen-address=${LISTEN_ADDRESS} -log.json=${LOG_JSON} -log.level=${LOG_LEVEL} -web.enable-reload=${ENABLE_RELOAD} -web.metrics-path=${METRICS_PATH} -web.config.file=${WEB_CONFIG_FILE}
 LimitNOFILE=10000
 TimeoutStopSec=20
 CapabilityBoundingSet=


### PR DESCRIPTION
## Notable changes

- Fix `log.level` typo in the systemd service for rpm package;
- Fix wrong environment file location in the systemd service for rpm package.

Fixes #242