### PR TITLE
Include scrape_timeout in the example sql_exporter.yml

### DIFF
--- a/examples/sql_exporter.yml
+++ b/examples/sql_exporter.yml
@@ -1,5 +1,7 @@
 # Global defaults.
 global:
+  # If scrape_timeout <= 0, no timeout is set unless Prometheus provides one. The default is 10s.
+  scrape_timeout: 10s
   # Subtracted from Prometheus' scrape_timeout to give us some headroom and prevent Prometheus from timing out first.
   scrape_timeout_offset: 500ms
   # Minimum interval between collector runs: by default (0s) collectors are executed on every scrape.


### PR DESCRIPTION
Prior to this patch, the first comment in `examples/sql_exporter.yml`:
```
# Subtracted from Prometheus' scrape_timeout to give us some headroom and prevent Prometheus from timing out first.
```

This was confusing to me, as the mentioned `scrape_timeout` is not present in the file. This patch should save someone else the 5 mins of head scratching