### PR TITLE
fix: enable up and duration for target if named

### DIFF
--- a/cmd/sql_exporter/main.go
+++ b/cmd/sql_exporter/main.go
@@ -133,7 +133,7 @@ func reloadCollectors(e sql_exporter.Exporter) func(http.ResponseWriter, *http.R
 		if currentConfig.Target != nil {
 			klog.Warning("Reloading target collectors...")
 			// FIXME: Should be t.Collectors() instead of config.Collectors
-			target, err := sql_exporter.NewTarget("", "", string(currentConfig.Target.DSN),
+			target, err := sql_exporter.NewTarget("", currentConfig.Target.Name, string(currentConfig.Target.DSN),
 				exporterNewConfig.Target.Collectors(), nil, currentConfig.Globals)
 			if err != nil {
 				klog.Errorf("Error recreating a target - %v", err)

--- a/config/config.go
+++ b/config/config.go
@@ -202,6 +202,7 @@ func (g *GlobalConfig) UnmarshalYAML(unmarshal func(any) error) error {
 
 // TargetConfig defines a DSN and a set of collectors to be executed on it.
 type TargetConfig struct {
+	Name          string   `yaml:"name,omitempty"`   // name of the target
 	DSN           Secret   `yaml:"data_source_name"` // data source name to connect to
 	AwsSecretName string   `yaml:"aws_secret_name"`  // AWS secret name
 	CollectorRefs []string `yaml:"collectors"`       // names of collectors to execute on the target

--- a/exporter.go
+++ b/exporter.go
@@ -56,7 +56,7 @@ func NewExporter(configFile string) (Exporter, error) {
 
 	var targets []Target
 	if c.Target != nil {
-		target, err := NewTarget("", "", string(c.Target.DSN), c.Target.Collectors(), nil, c.Globals)
+		target, err := NewTarget("", c.Target.Name, string(c.Target.DSN), c.Target.Collectors(), nil, c.Globals)
 		if err != nil {
 			return nil, err
 		}

--- a/target.go
+++ b/target.go
@@ -58,6 +58,7 @@ func NewTarget(
 ) {
 	if name != "" {
 		logContext = fmt.Sprintf("%s, target=%q", logContext, name)
+		constLabels = prometheus.Labels{"instance": name}
 	}
 
 	constLabelPairs := make([]*dto.LabelPair, 0, len(constLabels))


### PR DESCRIPTION
fixes #303

This PR enables `up` (availability) and `scrape_duration` metrics for a single target if `target.name` is populated in the config.

## Notes

Currently, the label `instance` is populated with target's name, which might look confusing. Given the fact that `jobs` also use `instance` for target names, we'll schedule the label change for both to `v0.13` for compatibility reasons.