### PR TITLE
fix: support NULL values for key labels

### DIFF
--- a/metric.go
+++ b/metric.go
@@ -1,6 +1,7 @@
 package sql_exporter
 
 import (
+	"database/sql"
 	"fmt"
 	"sort"
 
@@ -76,7 +77,7 @@ func NewMetricFamily(logContext string, mc *config.MetricConfig, constLabels []*
 func (mf MetricFamily) Collect(row map[string]any, ch chan<- Metric) {
 	labelValues := make([]string, len(mf.labels))
 	for i, label := range mf.config.KeyLabels {
-		labelValues[i] = row[label].(string)
+		labelValues[i] = row[label].(sql.NullString).String
 	}
 	for _, v := range mf.config.Values {
 		if mf.config.ValueLabel != "" {


### PR DESCRIPTION
## Description

At the moment, if at least one of the columns specified in `key_labels` contains `NULL` for a row, the query returns error and the metrics aren't published. It's by design of `database/sql` - NULL is not an empty string, so it cannot be converted to a string out of the box.

We actually want to support NULL values for metric labels (strings). If a row contains NULL in a column that's defined in `key_labels`, we return its value as an empty string. In addition we create a log (under debug log level) message, that the column value is NULL for a particular row.

fixes #317