### PR TITLE
fix: return partial results for multiple targets

### DIFF
--- a/cmd/sql_exporter/promhttp.go
+++ b/cmd/sql_exporter/promhttp.go
@@ -38,8 +38,6 @@ func ExporterHandlerFor(exporter sql_exporter.Exporter) http.Handler {
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
 				klog.Errorf("Timeout collecting metrics from target: %s", err)
-				http.Error(w, "Timeout collecting metrics from target, "+err.Error(), http.StatusInternalServerError)
-				return
 			}
 			if len(mfs) == 0 {
 				klog.Errorf("No metrics gathered: %s", err)
@@ -47,8 +45,6 @@ func ExporterHandlerFor(exporter sql_exporter.Exporter) http.Handler {
 				return
 			}
 			klog.Errorf("Error gathering metrics: %s", err)
-			http.Error(w, "Error gathering metrics, "+err.Error(), http.StatusInternalServerError)
-			return
 		}
 
 		contentType := expfmt.Negotiate(req.Header)


### PR DESCRIPTION
resolves #328 

It's fair that we would like to return partial results even if there are some errors for some of the targets.

This PR reverts some previously introduced logic, which doesn't play nicely with user expectations.