### PR TITLE
feat: set 'static_value' per metric config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -463,7 +463,8 @@ type MetricConfig struct {
 	QueryLiteral string            `yaml:"query,omitempty"`         // a literal query
 	QueryRef     string            `yaml:"query_ref,omitempty"`     // references a query in the query map
 
-	NoPreparedStatement bool `yaml:"no_prepared_statement,omitempty"` // do not prepare statement
+	NoPreparedStatement bool     `yaml:"no_prepared_statement,omitempty"` // do not prepare statement
+	StaticValue         *float64 `yaml:"static_value,omitempty"`
 
 	valueType prometheus.ValueType // TypeString converted to prometheus.ValueType
 	query     *QueryConfig         // QueryConfig resolved from QueryRef or generated from Query
@@ -527,8 +528,12 @@ func (m *MetricConfig) UnmarshalYAML(unmarshal func(any) error) error {
 		}
 	}
 
-	if len(m.Values) == 0 {
+	if len(m.Values) == 0 && m.StaticValue == nil {
 		return fmt.Errorf("no values defined for metric %q", m.Name)
+	}
+
+	if len(m.Values) > 0 && m.StaticValue != nil {
+		return fmt.Errorf("metric %q cannot have both static_value and values defined", m.Name)
 	}
 
 	if len(m.Values) > 1 {

--- a/metric.go
+++ b/metric.go
@@ -38,7 +38,7 @@ type MetricFamily struct {
 func NewMetricFamily(logContext string, mc *config.MetricConfig, constLabels []*dto.LabelPair) (*MetricFamily, errors.WithContext) {
 	logContext = fmt.Sprintf("%s, metric=%q", logContext, mc.Name)
 
-	if len(mc.Values) == 0 {
+	if len(mc.Values) == 0 && mc.StaticValue == nil {
 		return nil, errors.New(logContext, "no value column defined")
 	}
 	if len(mc.Values) > 1 && mc.ValueLabel == "" {
@@ -84,6 +84,10 @@ func (mf MetricFamily) Collect(row map[string]any, ch chan<- Metric) {
 			labelValues[len(labelValues)-1] = v
 		}
 		value := row[v].(float64)
+		ch <- NewMetric(&mf, value, labelValues...)
+	}
+	if mf.config.StaticValue != nil {
+		value := *mf.config.StaticValue
 		ch <- NewMetric(&mf, value, labelValues...)
 	}
 }


### PR DESCRIPTION
## Description

There are situations when we want to return some string data from the query (to re-process it later on the Prometheus side), and there's no value columns that could represent float64 number as a metric value. Even though we can solve it with some SQL adjustments, it's not always clear, when we look at SQL statements alone. It's also possible, that we simply cannot add a additional dummy value column due to different constraints (e.g. stored procedures we can't change) to point `values` parameter to.

To address this problem, we introduce metric configuration field `static_value` which can be set to a fixed number. The result is that we focus on the information mapped to `key_labels` instead, the value itself doesn't need to mean anything (although, the commonly used value would be `1`) and can be ignored later on.

`values` and `static_value` are mutually exclusive parameters.

## References

- https://www.robustperception.io/numbers-from-displaystrings-with-the-snmp_exporter/
- https://www.robustperception.io/converting-string-states-to-booleans-with-the-jmx-exporter/