### PR TITLE
feat: scrape_errors_total metric

### DIFF
--- a/cmd/sql_exporter/main.go
+++ b/cmd/sql_exporter/main.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	appName               string        = "sql_exporter"
 	envConfigFile         string        = "SQLEXPORTER_CONFIG"
 	envDebug              string        = "SQLEXPORTER_DEBUG"
 	httpReadHeaderTimeout time.Duration = time.Duration(time.Second * 60)
@@ -76,7 +77,7 @@ func main() {
 	}
 
 	if *showVersion {
-		fmt.Println(version.Print("sql_exporter"))
+		fmt.Println(version.Print(appName))
 		os.Exit(0)
 	}
 
@@ -105,11 +106,6 @@ func main() {
 		WebConfigFile: webConfigFile, WebSystemdSocket: OfBool(false)}, logger); err != nil {
 		klog.Fatal(err)
 	}
-}
-
-// OfBool returns bool address.
-func OfBool(i bool) *bool {
-	return &i
 }
 
 func reloadCollectors(e sql_exporter.Exporter) func(http.ResponseWriter, *http.Request) {
@@ -189,13 +185,4 @@ func reloadCollectors(e sql_exporter.Exporter) func(http.ResponseWriter, *http.R
 		klog.Warning("No target or jobs have been found - nothing to reload")
 		http.Error(w, "", http.StatusInternalServerError)
 	}
-}
-
-// LogFunc is an adapter to allow the use of any function as a promhttp.Logger. If f is a function, LogFunc(f) is a
-// promhttp.Logger that calls f.
-type LogFunc func(args ...any)
-
-// Println implements promhttp.Logger.
-func (log LogFunc) Println(args ...any) {
-	log(args)
 }

--- a/cmd/sql_exporter/promhttp.go
+++ b/cmd/sql_exporter/promhttp.go
@@ -1,15 +1,11 @@
 package main
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
 	"errors"
 	"io"
 	"net/http"
 	"strconv"
-	"strings"
-	"sync"
 	"time"
 
 	"github.com/burningalchemist/sql_exporter"
@@ -39,7 +35,7 @@ func ExporterHandlerFor(exporter sql_exporter.Exporter) http.Handler {
 		defer cancel()
 
 		// Go through prometheus.Gatherers to sanitize and sort metrics.
-		gatherer := prometheus.Gatherers{exporter.WithContext(ctx)}
+		gatherer := prometheus.Gatherers{exporter.WithContext(ctx), sql_exporter.SvcRegistry}
 		mfs, err := gatherer.Gather()
 		if err != nil {
 			switch t := err.(type) {
@@ -127,34 +123,4 @@ func contextFor(req *http.Request, exporter sql_exporter.Exporter) (context.Cont
 		return context.Background(), func() {}
 	}
 	return context.WithTimeout(context.Background(), timeout)
-}
-
-var bufPool sync.Pool
-
-func getBuf() *bytes.Buffer {
-	buf := bufPool.Get()
-	if buf == nil {
-		return &bytes.Buffer{}
-	}
-	return buf.(*bytes.Buffer)
-}
-
-func giveBuf(buf *bytes.Buffer) {
-	buf.Reset()
-	bufPool.Put(buf)
-}
-
-// decorateWriter wraps a writer to handle gzip compression if requested.  It
-// returns the decorated writer and the appropriate "Content-Encoding" header
-// (which is empty if no compression is enabled).
-func decorateWriter(request *http.Request, writer io.Writer) (w io.Writer, encoding string) {
-	header := request.Header.Get(acceptEncodingHeader)
-	parts := strings.Split(header, ",")
-	for _, part := range parts {
-		part := strings.TrimSpace(part)
-		if part == "gzip" || strings.HasPrefix(part, "gzip;") {
-			return gzip.NewWriter(writer), "gzip"
-		}
-	}
-	return writer, ""
 }

--- a/cmd/sql_exporter/util.go
+++ b/cmd/sql_exporter/util.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+var bufPool sync.Pool
+
+func getBuf() *bytes.Buffer {
+	buf := bufPool.Get()
+	if buf == nil {
+		return &bytes.Buffer{}
+	}
+	return buf.(*bytes.Buffer)
+}
+
+func giveBuf(buf *bytes.Buffer) {
+	buf.Reset()
+	bufPool.Put(buf)
+}
+
+// decorateWriter wraps a writer to handle gzip compression if requested.  It
+// returns the decorated writer and the appropriate "Content-Encoding" header
+// (which is empty if no compression is enabled).
+func decorateWriter(request *http.Request, writer io.Writer) (w io.Writer, encoding string) {
+	header := request.Header.Get(acceptEncodingHeader)
+	parts := strings.Split(header, ",")
+	for _, part := range parts {
+		part := strings.TrimSpace(part)
+		if part == "gzip" || strings.HasPrefix(part, "gzip;") {
+			return gzip.NewWriter(writer), "gzip"
+		}
+	}
+	return writer, ""
+}
+
+// LogFunc is an adapter to allow the use of any function as a promhttp.Logger. If f is a function, LogFunc(f) is a
+// promhttp.Logger that calls f.
+type LogFunc func(args ...interface{})
+
+// Println implements promhttp.Logger.
+func (log LogFunc) Println(args ...interface{}) {
+	log(args)
+}
+
+// OfBool returns bool address.
+func OfBool(i bool) *bool {
+	return &i
+}

--- a/collector.go
+++ b/collector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -31,6 +32,12 @@ type collector struct {
 // the provided const labels applied.
 func NewCollector(logContext string, cc *config.CollectorConfig, constLabels []*dto.LabelPair) (Collector, errors.WithContext) {
 	logContext = fmt.Sprintf(`%s,collector=%s`, logContext, cc.Name)
+
+	// Leading comma appears when previous parameter is undefined, which is a side-effect of running in single target mode.
+	// Let's trim to avoid confusions.
+	if strings.HasPrefix(logContext, ",") {
+		logContext = strings.TrimLeft(logContext, ", ")
+	}
 
 	// Maps each query to the list of metric families it populates.
 	queryMFs := make(map[*config.QueryConfig][]*MetricFamily, len(cc.Metrics))

--- a/collector.go
+++ b/collector.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -31,13 +30,7 @@ type collector struct {
 // NewCollector returns a new Collector with the given configuration and database. The metrics it creates will all have
 // the provided const labels applied.
 func NewCollector(logContext string, cc *config.CollectorConfig, constLabels []*dto.LabelPair) (Collector, errors.WithContext) {
-	logContext = fmt.Sprintf("%s, collector=%q", logContext, cc.Name)
-
-	// Leading comma appears when target name is undefined, which is a side-effect of running in single target mode.
-	// Let's trim to avoid confusions.
-	if strings.HasPrefix(logContext, ",") {
-		logContext = strings.TrimLeft(logContext, ", ")
-	}
+	logContext = fmt.Sprintf(`%s,collector=%s`, logContext, cc.Name)
 
 	// Maps each query to the list of metric families it populates.
 	queryMFs := make(map[*config.QueryConfig][]*MetricFamily, len(cc.Metrics))

--- a/config/config.go
+++ b/config/config.go
@@ -19,15 +19,17 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const EnvDsnOverride = "SQLEXPORTER_TARGET_DSN"
+
+// MaxInt32 defines the maximum value of allowed integers
+// and serves to help us avoid overflow/wraparound issues.
+const MaxInt32 int = 1<<31 - 1
+
 var (
 	EnablePing  bool
 	DsnOverride string
 	TargetLabel string
 )
-
-// MaxInt32 defines the maximum value of allowed integers
-// and serves to help us avoid overflow/wraparound issues.
-const MaxInt32 int = 1<<31 - 1
 
 // Load attempts to parse the given config file and return a Config object.
 func Load(configFile string) (*Config, error) {

--- a/exporter.go
+++ b/exporter.go
@@ -183,8 +183,8 @@ func (e *exporter) UpdateTarget(target []Target) {
 // registerSvcMetrics registers the metrics for the exporter itself.
 func registerSvcMetrics() *prometheus.CounterVec {
 	scrapeErrors := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "scrape_errors",
-		Help: "Total number of scrape errors per job, target, collector and query.",
+		Name: "scrape_errors_total",
+		Help: "Total number of scrape errors per job, target, collector and query",
 	}, svcMetricLabels)
 	SvcRegistry.MustRegister(scrapeErrors)
 	return scrapeErrors

--- a/exporter.go
+++ b/exporter.go
@@ -132,12 +132,14 @@ func (e *exporter) Gather() ([]*dto.MetricFamily, error) {
 		dtoMetric := &dto.Metric{}
 		if err := metric.Write(dtoMetric); err != nil {
 			errs = append(errs, err)
-			ctxLabels := parseLogCtx(err.Context())
-			e.scrapeErrors.WithLabelValues(
-				ctxLabels["job"],
-				ctxLabels["target"],
-				ctxLabels["collector"],
-				ctxLabels["query"]).Inc()
+			if err.Context() != "" {
+				ctxLabels := parseLogCtx(err.Context())
+				e.scrapeErrors.WithLabelValues(
+					ctxLabels["job"],
+					ctxLabels["target"],
+					ctxLabels["collector"],
+					ctxLabels["query"]).Inc()
+			}
 			continue
 		}
 		metricDesc := metric.Desc()

--- a/job.go
+++ b/job.go
@@ -25,7 +25,7 @@ func NewJob(jc *config.JobConfig, gc *config.GlobalConfig) (Job, errors.WithCont
 	j := job{
 		config:     jc,
 		targets:    make([]Target, 0, 10),
-		logContext: fmt.Sprintf("job=%q", jc.Name),
+		logContext: fmt.Sprintf(`job=%s`, jc.Name),
 	}
 
 	if jc.EnablePing == nil {

--- a/metric.go
+++ b/metric.go
@@ -36,7 +36,7 @@ type MetricFamily struct {
 
 // NewMetricFamily creates a new MetricFamily with the given metric config and const labels (e.g. job and instance).
 func NewMetricFamily(logContext string, mc *config.MetricConfig, constLabels []*dto.LabelPair) (*MetricFamily, errors.WithContext) {
-	logContext = fmt.Sprintf("%s, metric=%q", logContext, mc.Name)
+	logContext = fmt.Sprintf(`%s,metric=%s`, logContext, mc.Name)
 
 	if len(mc.Values) == 0 && mc.StaticValue == nil {
 		return nil, errors.New(logContext, "no value column defined")

--- a/query.go
+++ b/query.go
@@ -34,7 +34,7 @@ const (
 
 // NewQuery returns a new Query that will populate the given metric families.
 func NewQuery(logContext string, qc *config.QueryConfig, metricFamilies ...*MetricFamily) (*Query, errors.WithContext) {
-	logContext = fmt.Sprintf("%s, query=%q", logContext, qc.Name)
+	logContext = fmt.Sprintf(`%s,query=%s`, logContext, qc.Name)
 
 	columnTypes := make(columnTypeMap)
 
@@ -77,6 +77,7 @@ func setColumnType(logContext, columnName string, ctype columnType, columnTypes 
 func (q *Query) Collect(ctx context.Context, conn *sql.DB, ch chan<- Metric) {
 	if ctx.Err() != nil {
 		ch <- NewInvalidMetric(errors.Wrap(q.logContext, ctx.Err()))
+
 		return
 	}
 	rows, err := q.run(ctx, conn)

--- a/target.go
+++ b/target.go
@@ -6,7 +6,6 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/protobuf/proto"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -63,11 +63,7 @@ func NewTarget(
 		}
 	}
 
-	// Leading comma appears when target name is undefined, which is a side-effect of running in single target mode.
-	// Let's trim to avoid confusions.
-	if strings.HasPrefix(logContext, ",") {
-		logContext = strings.TrimLeft(logContext, ", ")
-	}
+	klog.Infof("[%s] Target ping enabled: %v", logContext, *ep)
 
 	// Sort const labels by name to ensure consistent ordering.
 	constLabelPairs := make([]*dto.LabelPair, 0, len(constLabels))

--- a/target.go
+++ b/target.go
@@ -57,7 +57,7 @@ func NewTarget(
 ) {
 
 	if tname != "" {
-		logContext = fmt.Sprintf("%s, target=%q", logContext, tname)
+		logContext = fmt.Sprintf("%s,target=%s", logContext, tname)
 		if constLabels == nil {
 			constLabels = prometheus.Labels{config.TargetLabel: tname}
 		}

--- a/target.go
+++ b/target.go
@@ -57,7 +57,7 @@ func NewTarget(
 ) {
 
 	if tname != "" {
-		logContext = fmt.Sprintf("%s,target=%s", logContext, tname)
+		logContext = fmt.Sprintf(`%s,target=%s`, logContext, tname)
 		if constLabels == nil {
 			constLabels = prometheus.Labels{config.TargetLabel: tname}
 		}

--- a/target.go
+++ b/target.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -62,6 +63,13 @@ func NewTarget(
 		}
 	}
 
+	// Leading comma appears when target name is undefined, which is a side-effect of running in single target mode.
+	// Let's trim to avoid confusions.
+	if strings.HasPrefix(logContext, ",") {
+		logContext = strings.TrimLeft(logContext, ", ")
+	}
+
+	// Sort const labels by name to ensure consistent ordering.
 	constLabelPairs := make([]*dto.LabelPair, 0, len(constLabels))
 	for n, v := range constLabels {
 		constLabelPairs = append(constLabelPairs, &dto.LabelPair{


### PR DESCRIPTION
## Notable changes

- Total number of scrape errors per job, target, collector and query. It's enabled if a target name is defined (for a single target). For jobs it's available automatically (since target names are populated automatically).

resolves #256