### PR TITLE
feat: add a helm chart with the releaser action

### DIFF
--- a/.github/workflows/helm-workflow.yaml
+++ b/.github/workflows/helm-workflow.yaml
@@ -1,0 +1,71 @@
+---
+name: Helm
+on: push
+
+jobs:
+  helm-jobs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.12.1
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.4.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --chart-dirs . --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --validate-maintainers=false --chart-dirs .
+
+      - name: Setup helmfile
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: mamezou-tech/setup-helmfile@v1.2.0          
+
+      - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.7.0
+
+      - name: Init postgres server
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          helmfile -f helm/ci/helmfile.yaml sync
+
+      - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --chart-dirs .
+
+      - name: Run chart-testing (upgrade)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --chart-dirs . --upgrade
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Release charts
+        if: ${{ github.ref == github.event.repository.default_branch }}
+        uses: helm/chart-releaser-action@v1.5.0
+        with:
+          charts_dir: .
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -12,3 +12,7 @@ keywords:
 home: https://github.com/burningalchemist/sql_exporter
 sources:
   - https://github.com/burningalchemist/sql_exporter
+maintainers:
+  - name: Nikolai Rodionov
+    email: allanger@zohomail.com
+    url: https://badhouseplants.net

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: sql-exporter
+description: Database agnostic SQL exporter for Prometheus
+type: application
+version: 0.1.0
+appVersion: 0.12.3
+keywords:
+  - exporter
+  - servicemonitor
+  - sql
+  - metrics
+home: https://github.com/burningalchemist/sql_exporter
+sources:
+  - https://github.com/burningalchemist/sql_exporter

--- a/helm/ci/helmfile.yaml
+++ b/helm/ci/helmfile.yaml
@@ -1,0 +1,37 @@
+repositories:
+  - name: bitnami
+    url: https://charts.bitnami.com/bitnami
+  - name: prometheus-community
+    url: https://prometheus-community.github.io/helm-charts
+
+releases:
+  - name: postgres-instance
+    installed: true
+    namespace: postgres
+    createNamespace: true
+    chart: bitnami/postgresql
+    values:
+      - global:
+          postgresql:
+            auth:
+              postgresPassword: 123123!!
+  - name: prometheus-stack
+    namespace: monitoring
+    createNamespace: true
+    chart: prometheus-community/kube-prometheus-stack
+    values:
+      - prometheus:
+          prometheusSpec:
+            enableAdminAPI: true
+            podMonitorNamespaceSelector:
+              any: true
+            podMonitorSelector: {}
+            podMonitorSelectorNilUsesHelmValues: false
+            ruleNamespaceSelector:
+              any: true
+            ruleSelector: {}
+            ruleSelectorNilUsesHelmValues: false
+            serviceMonitorNamespaceSelector:
+              any: true
+            serviceMonitorSelector: {}
+            serviceMonitorSelectorNilUsesHelmValues: false

--- a/helm/ci/postgresql-values.yaml
+++ b/helm/ci/postgresql-values.yaml
@@ -1,0 +1,53 @@
+tests:
+  serviceMonitor:
+    enabled: true
+    prom:
+      service: prometheus-operated
+      namespace: monitoring
+config:
+  target:
+    data_source_name: 'postgresql://postgres:123123!!@postgres-instance-postgresql.postgres.svc.cluster.local:5432?sslmode=disable'
+    collectors: [active_connections]
+  collectors:
+    - collector_name: active_connections
+      metrics:
+        - metric_name: active_connections
+          type: gauge
+          help: 'Active connections'
+          key_labels:
+            - "datname"
+            - "usename"
+            - "state"
+          values:
+            - "count"
+          query_ref: active_connections
+      queries:
+        - query_name: active_connections
+          query: |
+            SELECT
+              datname::text,
+              usename::text,
+              state::text,
+              COUNT(state)::float AS count
+            FROM pg_stat_activity
+            GROUP BY datname, usename, state;
+  collector_files:
+    - "*.collector.yml"
+collectorFiles:
+  pricing_data_freshness.collector.yml:
+    collector_name: pricing_data_freshness
+    metrics:
+      - metric_name: pricing_update_time
+        type: gauge
+        help: 'Time when prices for a market were last updated.'
+        key_labels:
+          # Populated from the `market` column of each row.
+          - Market
+        static_labels:
+          # Arbitrary key/value pair
+          portfolio: income
+        values: [LastUpdateTime]
+        query: |
+          SELECT Market, max(UpdateTime) AS LastUpdateTime
+          FROM MarketPrices
+          GROUP BY Market

--- a/helm/ci/postgresql-values.yaml
+++ b/helm/ci/postgresql-values.yaml
@@ -4,6 +4,8 @@ tests:
     prom:
       service: prometheus-operated
       namespace: monitoring
+  metricsEndpoint:
+    enabled: true
 
 config:
   target:

--- a/helm/ci/postgresql-values.yaml
+++ b/helm/ci/postgresql-values.yaml
@@ -4,6 +4,7 @@ tests:
     prom:
       service: prometheus-operated
       namespace: monitoring
+
 config:
   target:
     data_source_name: 'postgresql://postgres:123123!!@postgres-instance-postgresql.postgres.svc.cluster.local:5432?sslmode=disable'

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,0 +1,33 @@
+------------------------------
+Hello there! 
+
+{{- if and (not .Values.config.target ) (not .Values.config.jobs)}}
+------------------------------
+
+It seems like you haven't configured the target, please check the example here:
+ 
+ https://github.com/burningalchemist/sql_exporter/blob/master/documentation/sql_exporter.yml#L30
+
+In case you need to have multiple targets, you can confiure jobs instead, have a look here
+
+ https://github.com/burningalchemist/sql_exporter#multiple-database-connections
+
+{{- end}}
+
+{{- if and (not .Values.config.collectors) (not .Values.config.collectorFiles)}}
+
+------------------------------
+You need to configure either collectors or collectorFiles (or both), please have a look at the example here:
+
+ https://github.com/burningalchemist/sql_exporter#multiple-database-connections
+
+{{- end }}
+
+------------------------------
+If you want to test if the helm release is configured correctly, you can execute 
+
+ $ helm test {{ .Release.Name }}
+
+This test will check that sql_exported metrics endpoint returns status 200
+
+

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sql-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sql-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sql-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "sql-exporter.labels" -}}
+helm.sh/chart: {{ include "sql-exporter.chart" . }}
+{{ include "sql-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "sql-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sql-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sql-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "sql-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/templates/configmap.collectors.yaml
+++ b/helm/templates/configmap.collectors.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.collectorFiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sql-exporter.fullname" . }}
+  labels:
+    {{- include "sql-exporter.labels" . | nindent 4 }}
+data:
+  {{- range $k, $v := .Values.collectorFiles }}
+  {{ $k }}: |-
+    {{- toYaml $v | nindent 4}}
+  {{- end}}
+{{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sql-exporter.fullname" . }}
+  labels:
+    {{- include "sql-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "sql-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:        
+        checksum/config: {{ include (print $.Template.BasePath "/secret.configuration.yaml") . | sha256sum }}
+        checksum/collectors: {{ include (print $.Template.BasePath "/configmap.collectors.yaml") . | sha256sum }}
+      labels:
+        {{- include "sql-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: sql-exporter
+          secret:
+            secretName: {{ include "sql-exporter.fullname" . }}
+        {{- if .Values.collectorFiles }}
+        - name: sql-collector
+          configMap:
+            name: {{ include "sql-exporter.fullname" . }}
+        {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["-config.file=/etc/sql_exporter/sql_exporter.yml"]
+          volumeMounts:
+          - name: sql-exporter
+            readOnly: true
+            mountPath: /etc/sql_exporter/
+          {{- if .Values.collectorFiles }}
+          - name: sql-collector
+            readOnly: true
+            mountPath: /etc/sql_exporter
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9399
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9399
+          ports:
+            - name: http
+              containerPort: 9399
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           {{- if .Values.collectorFiles }}
           - name: sql-collector
             readOnly: true
-            mountPath: /etc/sql_exporter
+            mountPath: /etc/sql_exporter/collectors/
           {{- end }}
           livenessProbe:
             httpGet:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
       {{- include "sql-exporter.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      annotations:        
+      annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secret.configuration.yaml") . | sha256sum }}
         checksum/collectors: {{ include (print $.Template.BasePath "/configmap.collectors.yaml") . | sha256sum }}
       labels:

--- a/helm/templates/secret.configuration.yaml
+++ b/helm/templates/secret.configuration.yaml
@@ -1,0 +1,13 @@
+# ---------------------------------------------------------------------
+# -- This secret holds the config file of sql_exporter
+# ---------------------------------------------------------------------
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sql-exporter.fullname" . }}
+  labels:
+    {{- include "sql-exporter.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  sql_exporter.yml: |-
+    {{- toYaml .Values.config | nindent 4 }} 

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sql-exporter.fullname" . }}
+  labels:
+    {{- include "sql-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "sql-exporter.selectorLabels" . | nindent 4 }}

--- a/helm/templates/servicemonitor.yaml
+++ b/helm/templates/servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "sql-exporter.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "sql-exporter.labels" . | nindent 4 }}
+    {{- range $key, $value := .Values.serviceMonitor.selector }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+    {{- include "sql-exporter.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      {{- if .Values.serviceMonitor.path }}
+      path: {{ .Values.serviceMonitor.path }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.interval }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+{{- end }}

--- a/helm/templates/tests/test-connection.yaml
+++ b/helm/templates/tests/test-connection.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sql-exporter.fullname" . }}-test-script
+  labels:
+    {{- include "sql-exporter.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+  test.sh: |-
+    #! /bin/sh
+    STATUS=$(curl {{ include "sql-exporter.fullname" . }}:80/metrics --head -s | awk '/^HTTP/{print $2}')
+    if [ "$STATUS" != 200 ]; then
+      echo "sql-exporter didn't return code 200, probably something is broken"
+      exit 1;
+    fi
+    echo "metrics endpoint returned 200"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "sql-exporter.fullname" . }}-test-connection"
+  labels:
+    {{- include "sql-exporter.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  volumes:
+    - name: test-script
+      configMap:
+        name: "{{ include "sql-exporter.fullname" . }}-test-script"
+  containers:
+    - name: check-metrics-endpoint
+      image: alpine/curl
+      command: ['sh']
+      volumeMounts:
+        - name: test-script
+          readOnly: true
+          mountPath: /test.sh
+          subPath: test.sh
+      args:
+        - /test.sh
+  restartPolicy: Never

--- a/helm/templates/tests/test-connection.yaml
+++ b/helm/templates/tests/test-connection.yaml
@@ -1,3 +1,4 @@
+{{- if (((.Values.tests).metricsEndpoint).enabled) }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -46,3 +47,4 @@ spec:
       args:
         - /test.sh
   restartPolicy: Never
+{{- end }}

--- a/helm/templates/tests/test-servicemonitor.yaml
+++ b/helm/templates/tests/test-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tests.serviceMonitor.enabled }}
+{{- if (((.Values.tests).serviceMonitor).enabled) }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/helm/templates/tests/test-servicemonitor.yaml
+++ b/helm/templates/tests/test-servicemonitor.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.tests.serviceMonitor.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sql-exporter.fullname" . }}-test-prom-script
+  labels:
+    {{- include "sql-exporter.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+  test.sh: |-
+    #! /bin/sh
+    # -----------------------------------------------------------------
+    # -- JQ is required for this test, but since the jq image doesn't
+    # -- have curl installed, it's not an option to use it.
+    # -- Also, it doesn't have any shell installed, so we can't use
+    # -- it to copy the binary to an emptydir.
+    # -- That's why I'm using apk add here
+    # -----------------------------------------------------------------
+    apk update && apk add jq
+    sleep {{ .Values.serviceMonitor.interval }}
+    URL="{{.Values.tests.serviceMonitor.prom.service}}.{{.Values.tests.serviceMonitor.prom.namespace}}.svc.cluster.local"
+    CURL_RES=$(curl -q "http://${URL}:9090/api/v1/query?query=active_connections")
+    STATUS=$(echo "$CURL_RES" | jq -r '.status')
+    if [ "$STATUS" != "success" ]; then
+      echo "metric doesn't have a status 'success' in the prometheus"
+      echo "curl output is: $CURL_RES"
+      exit 1;
+    fi
+    echo "Prometheus rerturns success for the sql-exporter metric"
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "sql-exporter.fullname" . }}-test-prom"
+  labels:
+    {{- include "sql-exporter.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  volumes:
+    - name: test-script
+      configMap:
+        name: "{{ include "sql-exporter.fullname" . }}-test-prom-script"
+  containers:
+    - name: check-metrics-endpoint
+      image: alpine/curl
+      command:
+        - sh
+      volumeMounts:
+        - name: test-script
+          readOnly: true
+          mountPath: /test.sh
+          subPath: test.sh
+      args:
+        - /test.sh
+  restartPolicy: Never
+{{- end}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,110 @@
+# ---------------------------------------------------------------------
+# -- Global values
+# ---------------------------------------------------------------------
+image:
+  repository: burningalchemist/sql_exporter
+  pullPolicy: IfNotPresent
+#   tag: $IMAGE_TAG
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources: {}
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 100m
+#   memory: 128Mi
+
+podSecurityContext: {}
+securityContext: {}
+# capabilities:
+#   drop:
+#   - ALL
+# readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
+# ---------------------------------------------------------------------
+# -- Prometheus operator values
+# ---------------------------------------------------------------------
+serviceMonitor:
+  enabled: true
+  interval: 15s
+# ---------------------------------------------------------------------
+# -- SQL exporter configuration
+# -- For a comprehensive and comprehensively documented configuration
+# --  file check out: https://github.com/burningalchemist/sql_exporter/blob/master/documentation/sql_exporter.yml
+# ---------------------------------------------------------------------
+config:
+  global:
+    scrape_timeout: 10s
+    scrape_timeout_offset: 500ms
+    min_interval: 0s
+    max_connections: 3
+    max_idle_connections: 3
+# ---------------------------------------------------------------------
+# -- Target and collectors are not set so the chart is more flexible
+# -- Please configure it yourself
+# ---------------------------------------------------------------------
+#  target:
+#    data_source_name: 'sqlserver://prom_user:prom_password@dbserver1.example.com:1433'
+#    collectors: [active_connections]
+#  collectors:
+#    - collector_name: active_connections
+#      metrics:
+#        - metric_name: active_connections
+#          type: gauge
+#          help: 'Active connections'
+#          key_labels:
+#            - "datname"
+#            - "usename"
+#            - "state"
+#          values:
+#            - "count"
+#          query_ref: active_connections
+#      queries:
+#        - query_name: active_connections
+#          query: |
+#                  SELECT
+#                    datname::text,
+#                    usename::text,
+#                    state::text,
+#                    COUNT(state)::float AS count
+#                  FROM pg_stat_activity
+#                  GROUP BY datname, usename, state;
+#  collector_files:
+#    - "*.collector.yml"
+# ---------------------------------------------------------------------
+# -- Collector Files
+# ---------------------------------------------------------------------
+# -- Collector files are mounted to /etc/sql_exporter/collectors dir
+# ---------------------------------------------------------------------
+# collectorFiles:
+#   pricing_data_freshness.collector.yml: 
+#     collector_name: pricing_data_freshness
+#     metrics:
+#       - metric_name: pricing_update_time
+#         type: gauge
+#         help: 'Time when prices for a market were last updated.'
+#         key_labels:
+#           # Populated from the `market` column of each row.
+#           - Market
+#         static_labels:
+#           # Arbitrary key/value pair
+#           portfolio: income
+#         values: [LastUpdateTime]
+#         query: |
+#           SELECT Market, max(UpdateTime) AS LastUpdateTime
+#           FROM MarketPrices
+#           GROUP BY Market
+# ---------------------------------------------------------------------
+# -- These values only used for tests, users shouldn't set those
+# ---------------------------------------------------------------------
+tests:
+  serviceMonitor:
+    enabled: false

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,88 +4,88 @@
 image:
   repository: burningalchemist/sql_exporter
   pullPolicy: IfNotPresent
-#   tag: $IMAGE_TAG
-imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
+    #   tag: $IMAGE_TAG
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
 
-service:
-  type: ClusterIP
+  service:
+    type: ClusterIP
   port: 80
 
-resources: {}
-# limits:
-#   cpu: 100m
-#   memory: 128Mi
-# requests:
-#   cpu: 100m
-#   memory: 128Mi
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
 
-podSecurityContext: {}
-securityContext: {}
-# capabilities:
-#   drop:
-#   - ALL
-# readOnlyRootFilesystem: true
-# runAsNonRoot: true
-# runAsUser: 1000
-# ---------------------------------------------------------------------
-# -- Prometheus operator values
-# ---------------------------------------------------------------------
-serviceMonitor:
-  enabled: true
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+    # ---------------------------------------------------------------------
+    # -- Prometheus operator values
+    # ---------------------------------------------------------------------
+  serviceMonitor:
+    enabled: true
   interval: 15s
-# ---------------------------------------------------------------------
-# -- SQL exporter configuration
-# -- For a comprehensive and comprehensively documented configuration
-# --  file check out: https://github.com/burningalchemist/sql_exporter/blob/master/documentation/sql_exporter.yml
-# ---------------------------------------------------------------------
-config:
-  global:
-    scrape_timeout: 10s
+    # ---------------------------------------------------------------------
+    # -- SQL exporter configuration
+    # -- For a comprehensive and comprehensively documented configuration
+    # --  file check out: https://github.com/burningalchemist/sql_exporter/blob/master/documentation/sql_exporter.yml
+    # ---------------------------------------------------------------------
+  config:
+    global:
+      scrape_timeout: 10s
     scrape_timeout_offset: 500ms
     min_interval: 0s
     max_connections: 3
     max_idle_connections: 3
-# ---------------------------------------------------------------------
-# -- Target and collectors are not set so the chart is more flexible
-# -- Please configure it yourself
-# ---------------------------------------------------------------------
-#  target:
-#    data_source_name: 'sqlserver://prom_user:prom_password@dbserver1.example.com:1433'
-#    collectors: [active_connections]
-#  collectors:
-#    - collector_name: active_connections
-#      metrics:
-#        - metric_name: active_connections
-#          type: gauge
-#          help: 'Active connections'
-#          key_labels:
-#            - "datname"
-#            - "usename"
-#            - "state"
-#          values:
-#            - "count"
-#          query_ref: active_connections
-#      queries:
-#        - query_name: active_connections
-#          query: |
-#                  SELECT
-#                    datname::text,
-#                    usename::text,
-#                    state::text,
-#                    COUNT(state)::float AS count
-#                  FROM pg_stat_activity
-#                  GROUP BY datname, usename, state;
-#  collector_files:
-#    - "*.collector.yml"
+      # ---------------------------------------------------------------------
+      # -- Target and collectors are not set so the chart is more flexible
+      # -- Please configure it yourself
+      # ---------------------------------------------------------------------
+      #  target:
+      #    data_source_name: 'sqlserver://prom_user:prom_password@dbserver1.example.com:1433'
+      #    collectors: [active_connections]
+      #  collectors:
+      #    - collector_name: active_connections
+      #      metrics:
+      #        - metric_name: active_connections
+      #          type: gauge
+      #          help: 'Active connections'
+      #          key_labels:
+      #            - "datname"
+      #            - "usename"
+      #            - "state"
+      #          values:
+      #            - "count"
+      #          query_ref: active_connections
+      #      queries:
+      #        - query_name: active_connections
+      #          query: |
+      #                  SELECT
+      #                    datname::text,
+      #                    usename::text,
+      #                    state::text,
+      #                    COUNT(state)::float AS count
+      #                  FROM pg_stat_activity
+      #                  GROUP BY datname, usename, state;
+      #  collector_files:
+      #    - "*.collector.yml"
 # ---------------------------------------------------------------------
 # -- Collector Files
 # ---------------------------------------------------------------------
-# -- Collector files are mounted to /etc/sql_exporter/collectors dir
+# -- Collector files are mounter to /etc/sql_exporter/collectors dir
 # ---------------------------------------------------------------------
 # collectorFiles:
-#   pricing_data_freshness.collector.yml: 
+#   pricing_data_freshness.collector.yml:
 #     collector_name: pricing_data_freshness
 #     metrics:
 #       - metric_name: pricing_update_time

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,84 +5,86 @@ image:
   repository: burningalchemist/sql_exporter
   pullPolicy: IfNotPresent
     #   tag: $IMAGE_TAG
-  imagePullSecrets: []
-  nameOverride: ""
-  fullnameOverride: ""
-
-  service:
-    type: ClusterIP
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+service:
+  type: ClusterIP
   port: 80
+resources:
+  {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+podSecurityContext: {}
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
 
-  resources: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
-
-  podSecurityContext: {}
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
-    # ---------------------------------------------------------------------
-    # -- Prometheus operator values
-    # ---------------------------------------------------------------------
-  serviceMonitor:
-    enabled: true
+# ---------------------------------------------------------------------
+# -- Prometheus operator values
+# ---------------------------------------------------------------------
+serviceMonitor:
+  enabled: true
   interval: 15s
-    # ---------------------------------------------------------------------
-    # -- SQL exporter configuration
-    # -- For a comprehensive and comprehensively documented configuration
-    # --  file check out: https://github.com/burningalchemist/sql_exporter/blob/master/documentation/sql_exporter.yml
-    # ---------------------------------------------------------------------
-  config:
-    global:
-      scrape_timeout: 10s
+  # ---------------------------------------------------------------------
+  # -- SQL exporter configuration
+  # -- For a comprehensive and comprehensively documented configuration
+  # --  file check out: https://github.com/burningalchemist/sql_exporter/blob/master/documentation/sql_exporter.yml
+  # ---------------------------------------------------------------------
+
+config:
+  global:
+    scrape_timeout: 10s
     scrape_timeout_offset: 500ms
     min_interval: 0s
     max_connections: 3
     max_idle_connections: 3
-      # ---------------------------------------------------------------------
-      # -- Target and collectors are not set so the chart is more flexible
-      # -- Please configure it yourself
-      # ---------------------------------------------------------------------
-      #  target:
-      #    data_source_name: 'sqlserver://prom_user:prom_password@dbserver1.example.com:1433'
-      #    collectors: [active_connections]
-      #  collectors:
-      #    - collector_name: active_connections
-      #      metrics:
-      #        - metric_name: active_connections
-      #          type: gauge
-      #          help: 'Active connections'
-      #          key_labels:
-      #            - "datname"
-      #            - "usename"
-      #            - "state"
-      #          values:
-      #            - "count"
-      #          query_ref: active_connections
-      #      queries:
-      #        - query_name: active_connections
-      #          query: |
-      #                  SELECT
-      #                    datname::text,
-      #                    usename::text,
-      #                    state::text,
-      #                    COUNT(state)::float AS count
-      #                  FROM pg_stat_activity
-      #                  GROUP BY datname, usename, state;
-      #  collector_files:
-      #    - "*.collector.yml"
+  # ---------------------------------------------------------------------
+  # -- Target and collectors are not set so the chart is more flexible
+  # -- Please configure it yourself
+  # ---------------------------------------------------------------------
+  #  target:
+  #    data_source_name: 'sqlserver://prom_user:prom_password@dbserver1.example.com:1433'
+  #    collectors: [active_connections]
+  #  collectors:
+  #    - collector_name: active_connections
+  #      metrics:
+  #        - metric_name: active_connections
+  #          type: gauge
+  #          help: 'Active connections'
+  #          key_labels:
+  #            - "datname"
+  #            - "usename"
+  #            - "state"
+  #          values:
+  #            - "count"
+  #          query_ref: active_connections
+  #      queries:
+  #        - query_name: active_connections
+  #          query: |
+  #                  SELECT
+  #                    datname::text,
+  #                    usename::text,
+  #                    state::text,
+  #                    COUNT(state)::float AS count
+  #                  FROM pg_stat_activity
+  #                  GROUP BY datname, usename, state;
+  #  collector_files:
+  #    - "*.collector.yml"
+
 # ---------------------------------------------------------------------
 # -- Collector Files
 # ---------------------------------------------------------------------
-# -- Collector files are mounter to /etc/sql_exporter/collectors dir
+# -- Collector files are mounted to /etc/sql_exporter/collectors dir
 # ---------------------------------------------------------------------
 # collectorFiles:
 #   pricing_data_freshness.collector.yml:
@@ -102,9 +104,3 @@ image:
 #           SELECT Market, max(UpdateTime) AS LastUpdateTime
 #           FROM MarketPrices
 #           GROUP BY Market
-# ---------------------------------------------------------------------
-# -- These values only used for tests, users shouldn't set those
-# ---------------------------------------------------------------------
-tests:
-  serviceMonitor:
-    enabled: false


### PR DESCRIPTION
Hi!

I thought of starting to use `sql_exporter` on k8s, but I found out that there was no helm chart available, so I've decided to come up with one.

This PR contains the helm chart and the new GitHub action that will lint, test and release that chart. The release action requires GitHub pages enabled, because it's using it as a helm repository, you can check it in my fork: https://github.com/allanger/sql_exporter/tree/gh-pages

In this PR, release is enabled only when the action is triggered by pushing to the master, but since the action is checking if there were changes to the chart before releasing, it will require one more commit with a version bump to release the first version. 

When the new chart version is released, it will be put to GitHub releases and GitHub pages branch will be updated. Having it in GitHub releases may not be a desired behavior, since it will conflict with actual release.  If it's the case, I guess it's possible to disable it and put releases directly to the pages branch. 


What about maintenance?

I can take care of it for a time being. But basically, if there are no breaking changed introduced to the tool, the whole maintenance will be just upgrading `helm/Chart.yaml:appVersion` to the new app version and `helm/Chart.yaml/version` to the following one.
