### PR TITLE
chore: Update the helm chart version for the first release

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database agnostic SQL exporter for Prometheus
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.12.3
 keywords:
   - exporter


### PR DESCRIPTION
    It's required now without any actual changes to the chart to trigger the
    first release. The releaser tool will compare the state to previous
    master and trigger a release. It will be uploaded to GitHub releases of
    the project and also it should create a file index.yaml that should be
    pushed to the gh-pages branch. This branch should also be the one that
    is used for the GitHub Pages feature. And it should be done before
    merging this PR to the master.

    The easiest way to create it would be

    $ git checkout --orphan gh-pages
    $ git rm --cached -r  .
    $ git clean -f -d .
    $ git commit --allow-empty -m "Init GitHub pages branch"
    $ git push --set-upstream origin gh-pages

    Then go to GitHub project settings -> Pages -> Choose the branch to
    deploy from. After it's done, this commit should be merged to the
    master, and the chart will be accessible for users