### PR TITLE
build: Compare current chart to latest released

### DIFF
--- a/.github/workflows/helm-workflow.yaml
+++ b/.github/workflows/helm-workflow.yaml
@@ -1,4 +1,3 @@
----
 name: Helm
 on:
   push:
@@ -7,7 +6,11 @@ on:
   pull_request:
     branches:
       - master
-
+env:
+  HELM_VERSION: 3.12.1
+  PYTHON_VERSION: 3.9
+  TARGET_BRANCH: chart-testing-target-branch
+  TARGET_REMOTE: test
 jobs:
   helm-jobs:
     runs-on: ubuntu-latest
@@ -16,62 +19,95 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.12.1
-
+          version: "v${{ env.HELM_VERSION }}"
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: ${{ env.PYTHON_VERSION }}
           check-latest: true
-
+      # ---------------------------------------------------------------
+      # -- Instead of comparing to the master branch, I'm getting
+      # --  the commit hash set in the previous step from a
+      # --  currently released chart. If it doesn't exists, then
+      # --  I assume that chart is not released and compare to the
+      # --  previous commit 
+      # --
+      # -- Also, I'm setting the RepoURL here. Since we plan to support
+      # --  the official chart in this git repository, the helm
+      # --  repository is expected to belong to this repo as well.
+      # ---------------------------------------------------------------
+      - name: Retrieve the latest commit sha from the helm chart
+        run: |
+          HELM_REPO_URL="https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#*/}"
+          if helm repo add sql-exporter $HELM_REPO_URL
+          then
+            helm repo update
+            echo "TARGET_COMMIT=$(helm show chart sql-exporter/sql-exporter | yq '.annotations.git/commit-sha')" >> "${GITHUB_ENV}"
+          else
+            echo "TARGET_COMMIT=$(git show HEAD^1 --pretty=format:%H --no-patch)" >> "${GITHUB_ENV}"
+          fi
+      # ---------------------------------------------------------------
+      # -- As I could find CT doesn't support testing against commits
+      # --  directly, so I'm creating a new fake remote from a commit
+      # --  and testing the chart against it. This workaround doesn't
+      # --  support maintainers validation, but we have it disabled
+      # --  anyway
+      # ---------------------------------------------------------------
+      - name: Prepare a dummy remote to test the chart
+        run: |
+          DUMMY_REMOTE=$(mktemp -d)
+          git init "${DUMMY_REMOTE}"
+          git remote add "${TARGET_REMOTE}" "${DUMMY_REMOTE}"
+          git checkout -b "${TARGET_BRANCH}" "${TARGET_COMMIT}"
+          git push --set-upstream "${TARGET_REMOTE}" "${TARGET_BRANCH}"
+          git checkout "${GITHUB_SHA}"
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.4.0
-
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --chart-dirs . --target-branch ${{ github.event.repository.default_branch }})
+          changed=$(ct list-changed --chart-dirs . --target-branch "${TARGET_BRANCH}" --remote "${TARGET_REMOTE}")
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
-
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --validate-maintainers=false --chart-dirs .
-
+        run: ct lint --target-branch "${TARGET_BRANCH}" --remote "${TARGET_REMOTE}" --validate-maintainers=false --chart-dirs .
       - name: Setup helmfile
         if: steps.list-changed.outputs.changed == 'true'
-        uses: mamezou-tech/setup-helmfile@v1.2.0          
-
+        uses: mamezou-tech/setup-helmfile@v1.2.0
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.7.0
-
       - name: Init postgres server
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           helmfile -f helm/ci/helmfile.yaml sync
-
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --chart-dirs .
-
+        run: ct install --target-branch "${TARGET_BRANCH}" --remote "${TARGET_REMOTE}" --chart-dirs .
       - name: Run chart-testing (upgrade)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --chart-dirs . --upgrade
-
+        run: ct install --target-branch "${TARGET_BRANCH}" --remote "${TARGET_REMOTE}" --chart-dirs . --upgrade
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      # ---------------------------------------------------------------
+      # -- On each run we're setting an annotation with the current
+      # --  commit hash, so in case it's released, we will see it
+      # --  running `$ helm show sql-exporter/sql-exporter`
+      # ---------------------------------------------------------------
+      - name: Set the git sha annotations in the helm chart
+        run: yq -i ".annotations.git/commit-sha = \"${GITHUB_SHA}\"" ./helm/Chart.yaml
 
       - name: Release charts
-        if: ${{ github.ref == github.event.repository.default_branch }}
+        if: ${{ github.event.repository.default_branch && github.event_name == 'push' }}
         uses: helm/chart-releaser-action@v1.5.0
         with:
           charts_dir: .
+          mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database agnostic SQL exporter for Prometheus
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.12.3
 keywords:
   - exporter


### PR DESCRIPTION
I've added a step to the helm-workflow, that is adding an annotation to the helm chart manifests. This annotations contains a SHA of a current commit. If the action is triggered by puhsing to the master, this annotations will be preserved and will make it to the upstream manifests, though it's not visible in the git repo.

I'm adding to identify the the commit to which we should compare the current version of the chart. If it's not accessible, the chart will be compared to the previous commit, that basically means that there is no released version yet.

I've also added a repo URL to chart annotations, so we can get the chart from the upstream repo to retrieve the SHA annotations from the upstream chart. It should make it possible to use the same workflow in forked repos, if an intention behind forking is merging something to the upstream repo.