### PR TITLE
build: Switch helm-releaser to the main branch

### DIFF
--- a/.github/workflows/helm-workflow.yaml
+++ b/.github/workflows/helm-workflow.yaml
@@ -105,9 +105,10 @@ jobs:
 
       - name: Release charts
         if: ${{ github.event.repository.default_branch && github.event_name == 'push' }}
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@main
         with:
           charts_dir: .
           mark_as_latest: false
+          packages_with_index: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database agnostic SQL exporter for Prometheus
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: 0.12.3
 keywords:
   - exporter

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -23,11 +23,3 @@ You need to configure either collectors or collectorFiles (or both), please have
 
 {{- end }}
 
-------------------------------
-If you want to test if the helm release is configured correctly, you can execute 
-
- $ helm test {{ .Release.Name }}
-
-This test will check that sql_exported metrics endpoint returns status 200
-
-


### PR DESCRIPTION
We need to use some features that are available only in the main branch at the moment. So until the next version is released, I'd suggest switching to the main revision.

Also, I've removed a notice about helm tests from NOTES.TXT, because we are not rendering tests anymore by default, and hence this note might be confusing