### PR TITLE
fix(helm): scrapeTimeout and interval clash, release v0.2.2

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database agnostic SQL exporter for Prometheus
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.13.0
 keywords:
   - exporter

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.0](https://img.shields.io/badge/AppVersion-0.13.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.0](https://img.shields.io/badge/AppVersion-0.13.0-informational?style=flat-square)
 
 Database agnostic SQL exporter for Prometheus
 
@@ -51,7 +51,7 @@ helm install sql_exporter/sql-exporter
 | serviceMonitor.enabled | bool | `true` | Enable ServiceMonitor |
 | serviceMonitor.interval | string | `"15s"` | ServiceMonitor interval |
 | serviceMonitor.path | string | `"/metrics"` | ServiceMonitor path |
-| serviceMonitor.scrapeTimeout | string | `"60s"` | ServiceMonitor scrape timeout |
+| serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout |
 
 ### Configuration
 

--- a/helm/README.md.gotmpl
+++ b/helm/README.md.gotmpl
@@ -42,6 +42,7 @@ helm install sql_exporter/sql-exporter
 | {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
   {{- end }}
 {{- end }}
+| serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout |
 
 ### Configuration
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -62,7 +62,7 @@ serviceMonitor:
   # -- ServiceMonitor path
   path: /metrics
   # -- ServiceMonitor scrape timeout
-  scrapeTimeout: 60s
+  # scrapeTimeout: 10s
 
 config:
   global:


### PR DESCRIPTION
Adding `scrapeTimeout` with random value broke things:

```
error="scrapeTimeout \"60s\" greater than scrapeInterval \"15s\""
```

It's better to leave scrapeTimeout unset (was some sane commented out default).