### PR TITLE
Add existing secrets to helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ sc.exe create SqlExporterSvc binPath= "%SQL_EXPORTER_PATH%\sql_exporter.exe --co
 `%SQL_EXPORTER_PATH%` is a path to the SQL Exporter binary executable. This document assumes that configuration files
 are in the same location.
 
+## Helm installation
+
+A Helm chart is available for SQL Exporter. It can be installed by running the following commands:
+
+**TL;DR**
+```shell
+helm repo add burningalchemist https://burningalchemist.github.io
+helm intall burningalchemist/sql-exporter
+```
+
+
 ## Configuration
 
 SQL Exporter is deployed alongside the DB server it collects metrics from. If both the exporter and the DB
@@ -251,7 +262,7 @@ the secret. Policy example:
       "Effect": "Allow",
       "Principal": {"AWS": "arn:aws:iam::123456789012:role/EC2RoleToAccessSecrets"},
       "Action": "secretsmanager:GetSecretValue",
-      "Resource": "*",
+      "Resource": "*"
     }
   ]
 }

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database agnostic SQL exporter for Prometheus
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: 0.13.1
 keywords:
   - exporter

--- a/helm/README.md
+++ b/helm/README.md
@@ -57,11 +57,12 @@ helm install sql_exporter/sql-exporter
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| config.global.scrape_timeout | string | `"10s"` | Scrape timeout |
-| config.global.scrape_timeout_offset | string | `"500ms"` | Scrape timeout offset. Must be strictly positive. |
-| config.global.min_interval | string | `"0s"` | Minimum interval between collector runs. |
-| config.global.max_connections | int | `3` | Number of open connections. |
-| config.global.max_idle_connections | int | `3` | Number of idle connections. |
+| config.from | object | `{}` | Option to provide an existing secret or configmap with all the values from the config section |
+| config.value.global.scrape_timeout | string | `"10s"` | Scrape timeout |
+| config.value.global.scrape_timeout_offset | string | `"500ms"` | Scrape timeout offset. Must be strictly positive. |
+| config.value.global.min_interval | string | `"0s"` | Minimum interval between collector runs. |
+| config.value.global.max_connections | int | `3` | Number of open connections. |
+| config.value.global.max_idle_connections | int | `3` | Number of idle connections. |
 | target | object | `nil` | Check documentation. Mutually exclusive with `jobs`  |
 | jobs   | list | `nil` | Check documentation. Mutually exclusive with `target` |
 | collector_files | list | `[]` | Check documentation |

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,8 @@
 # sql-exporter
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.1](https://img.shields.io/badge/AppVersion-0.13.1-informational?style=flat-square)
+
+
+![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.1](https://img.shields.io/badge/AppVersion-0.13.1-informational?style=flat-square)
 
 Database agnostic SQL exporter for Prometheus
 
@@ -57,7 +59,7 @@ helm install sql_exporter/sql-exporter
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| config.from | object | `{}` | Option to provide an existing secret or configmap with all the values from the config section |
+| config.from | object | `{}` | Option to provide an existing secret or configmap with all the values from the config section. If set, it will take precedence and override all other values in the config.value section. |
 | config.value.global.scrape_timeout | string | `"10s"` | Scrape timeout |
 | config.value.global.scrape_timeout_offset | string | `"500ms"` | Scrape timeout offset. Must be strictly positive. |
 | config.value.global.min_interval | string | `"0s"` | Minimum interval between collector runs. |

--- a/helm/README.md
+++ b/helm/README.md
@@ -2,7 +2,7 @@
 
 
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.1](https://img.shields.io/badge/AppVersion-0.13.1-informational?style=flat-square)
+![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.13.1](https://img.shields.io/badge/AppVersion-0.13.1-informational?style=flat-square) 
 
 Database agnostic SQL exporter for Prometheus
 
@@ -15,6 +15,9 @@ Database agnostic SQL exporter for Prometheus
 | Name | Email | Url |
 | ---- | ------ | --- |
 | Nikolai Rodionov | <allanger@zohomail.com> | <https://badhouseplants.net> |
+
+
+
 
 ## Installing the Chart
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -32,7 +32,11 @@ spec:
       volumes:
         - name: sql-exporter
           secret:
+            {{- if .Values.existingSecret }}
+            secretName: {{ .Values.existingSecret }}
+            {{- else }}
             secretName: {{ include "sql-exporter.fullname" . }}
+            {{- end }}
         {{- if .Values.collectorFiles }}
         - name: sql-collector
           configMap:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -31,12 +31,22 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
         - name: sql-exporter
+          {{- if eq .Values.config.from.kind "ConfigMap" }}
+          configMap:
+            name: {{ .Values.config.from.name }}
+            items:
+              - key: {{ .Values.config.from.key }}
+                path: "sql_exporter.yml"
+          {{- else if eq .Values.config.from.kind "Secret" }}
           secret:
-            {{- if .Values.existingSecret }}
-            secretName: {{ .Values.existingSecret }}
-            {{- else }}
+            secretName: {{ .Values.config.from.name }}
+            items:
+              - key: {{ .Values.config.from.key }}
+                path: "sql_exporter.yml"
+          {{- else }}
+          secret:
             secretName: {{ include "sql-exporter.fullname" . }}
-            {{- end }}
+          {{- end }}
         {{- if .Values.collectorFiles }}
         - name: sql-collector
           configMap:

--- a/helm/templates/secret.configuration.yaml
+++ b/helm/templates/secret.configuration.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 # ---------------------------------------------------------------------
 # -- This secret holds the config file of sql_exporter
 # ---------------------------------------------------------------------
@@ -11,3 +12,4 @@ type: Opaque
 stringData:
   sql_exporter.yml: |-
     {{- toYaml .Values.config | nindent 4 }} 
+{{- end }}

--- a/helm/templates/secret.configuration.yaml
+++ b/helm/templates/secret.configuration.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.existingSecret }}
+{{- if not .Values.config.from }}
 # ---------------------------------------------------------------------
 # -- This secret holds the config file of sql_exporter
 # ---------------------------------------------------------------------
@@ -11,5 +11,5 @@ metadata:
 type: Opaque
 stringData:
   sql_exporter.yml: |-
-    {{- toYaml .Values.config | nindent 4 }} 
+    {{- toYaml .Values.config.value | nindent 4 }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -77,6 +77,12 @@ serviceMonitor:
 #       kind: Secret
 #       name: sql_exporter_secret
 #       key: CONNECTION_STRING
+
+# ---------------------------------------------------------------------
+# -- Option to provide an existing secret with all the values from the config section
+# ---------------------------------------------------------------------
+existingSecret: {}
+
 config:
   global:
     # -- Scrape timeout

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -78,23 +78,25 @@ serviceMonitor:
 #       name: sql_exporter_secret
 #       key: CONNECTION_STRING
 
-# ---------------------------------------------------------------------
-# -- Option to provide an existing secret with all the values from the config section
-# ---------------------------------------------------------------------
-existingSecret: {}
 
 config:
-  global:
-    # -- Scrape timeout
-    scrape_timeout: 10s
-    # -- Scrape timeout offset. Must be strictly positive.
-    scrape_timeout_offset: 500ms
-    # -- Minimum interval between collector runs.
-    min_interval: 0s
-    # -- Number of open connections.
-    max_connections: 3
-    # -- Number of idle connections.
-    max_idle_connections: 3
+  # -- Option to provide an existing secret or configmap with all the values from the config section
+  from: {}
+#    kind: Secret
+#    name: sql_exporter_secret
+#    key:  sql_exporter.yml
+  value:
+    global:
+      # -- Scrape timeout
+      scrape_timeout: 10s
+      # -- Scrape timeout offset. Must be strictly positive.
+      scrape_timeout_offset: 500ms
+      # -- Minimum interval between collector runs.
+      min_interval: 0s
+      # -- Number of open connections.
+      max_connections: 3
+      # -- Number of idle connections.
+      max_idle_connections: 3
 # Target and collectors are not set so the chart is more flexible. Please configure it yourself.
 # target:
 #   data_source_name: 'sqlserver://prom_user:prom_password@dbserver1.example.com:1433'

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -80,7 +80,8 @@ serviceMonitor:
 
 
 config:
-  # -- Option to provide an existing secret or configmap with all the values from the config section
+  # -- Option to provide an existing secret or configmap with all the values from the config section. If set, it will
+  # take precedence and override all other values in the config.value section.
   from: {}
 #    kind: Secret
 #    name: sql_exporter_secret


### PR DESCRIPTION
This PR adds the possibility to use an existing kubernetes secret when installing sql-exporter with the helm chart.

Related to #396 