### PR TITLE
fix: add flag to ignore results with missing values

### DIFF
--- a/cmd/sql_exporter/main.go
+++ b/cmd/sql_exporter/main.go
@@ -41,6 +41,7 @@ var (
 func init() {
 	prometheus.MustRegister(version.NewCollector("sql_exporter"))
 	flag.BoolVar(&cfg.EnablePing, "config.enable-ping", true, "Enable ping for targets")
+	flag.BoolVar(&cfg.IgnoreMissingVals, "config.ignore-missing-values", false, "[EXPERIMENTAL] Ignore results with missing values for the requested columns")
 	flag.StringVar(&cfg.DsnOverride, "config.data-source-name", "", "Data source name to override the value in the configuration file with")
 	flag.StringVar(&cfg.TargetLabel, "config.target-label", "target", "Target label name")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -26,9 +26,10 @@ const EnvDsnOverride = "SQLEXPORTER_TARGET_DSN"
 const MaxInt32 int = 1<<31 - 1
 
 var (
-	EnablePing  bool
-	DsnOverride string
-	TargetLabel string
+	EnablePing        bool
+	IgnoreMissingVals bool
+	DsnOverride       string
+	TargetLabel       string
 )
 
 // Load attempts to parse the given config file and return a Config object.

--- a/query.go
+++ b/query.go
@@ -89,6 +89,10 @@ func (q *Query) Collect(ctx context.Context, conn *sql.DB, ch chan<- Metric) {
 
 	dest, err := q.scanDest(rows)
 	if err != nil {
+		if config.IgnoreMissingVals {
+			klog.V(3).Info(err)
+			return
+		}
 		ch <- NewInvalidMetric(err)
 		return
 	}


### PR DESCRIPTION
resolves #400

When set to true, errors on the missing values for the requested columns are reported at Info (Debug in the `klog-gokit` translation) log level, invisible by default.

Setting this flag on reduces the amount of noisy log messages users are aware of (check the original user story). The metric with missing labels doesn't get collected nor reported as an invalid metric. Off by default.