### PR TITLE
feat: return metric with an explicit timestamp from the configured column

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ metrics:
     # Static metric value (optional). Useful in case we are interested in string data (key_labels) only. It's mutually
     # exclusive with `values` field.
     # static_value: 1
+    # Timestamp value (optional). Should point at the existing column containing valid timestamps to return a metric
+    # with an explicit timestamp.
+    # timestamp_value: CreatedAt
     query: |
       SELECT Market, max(UpdateTime) AS LastUpdateTime
       FROM MarketPrices

--- a/config/metric_config.go
+++ b/config/metric_config.go
@@ -20,8 +20,9 @@ type MetricConfig struct {
 	QueryLiteral string            `yaml:"query,omitempty"`         // a literal query
 	QueryRef     string            `yaml:"query_ref,omitempty"`     // references a query in the query map
 
-	NoPreparedStatement bool     `yaml:"no_prepared_statement,omitempty"` // do not prepare statement
-	StaticValue         *float64 `yaml:"static_value,omitempty"`
+	NoPreparedStatement bool      `yaml:"no_prepared_statement,omitempty"` // do not prepare statement
+	StaticValue         *float64  `yaml:"static_value,omitempty"`
+	TimeValue           string `yaml:"time_value,omitempty"` // with multiple value columns, map their names under this label
 
 	valueType prometheus.ValueType // TypeString converted to prometheus.ValueType
 	query     *QueryConfig         // QueryConfig resolved from QueryRef or generated from Query

--- a/config/metric_config.go
+++ b/config/metric_config.go
@@ -20,9 +20,9 @@ type MetricConfig struct {
 	QueryLiteral string            `yaml:"query,omitempty"`         // a literal query
 	QueryRef     string            `yaml:"query_ref,omitempty"`     // references a query in the query map
 
-	NoPreparedStatement bool      `yaml:"no_prepared_statement,omitempty"` // do not prepare statement
-	StaticValue         *float64  `yaml:"static_value,omitempty"`
-	TimeValue           string `yaml:"time_value,omitempty"` // with multiple value columns, map their names under this label
+	NoPreparedStatement bool     `yaml:"no_prepared_statement,omitempty"` // do not prepare statement
+	StaticValue         *float64 `yaml:"static_value,omitempty"`
+	TimestampValue      string   `yaml:"timestamp_value,omitempty"` // optional column name containing a valid timestamp value
 
 	valueType prometheus.ValueType // TypeString converted to prometheus.ValueType
 	query     *QueryConfig         // QueryConfig resolved from QueryRef or generated from Query

--- a/documentation/sql_exporter.yml
+++ b/documentation/sql_exporter.yml
@@ -76,6 +76,9 @@ collectors:
         # Arbitrary key/value pair
           env: dev
           region: europe
+        # Optional timestamp_value to point at the existing timestamp column to return a metric with an explicit
+        # timestamp.
+        # timestamp_value: CreatedAt
         # This query returns exactly one value per row, in the `counter` column.
         values: [counter]
         query: |

--- a/metric.go
+++ b/metric.go
@@ -87,10 +87,10 @@ func (mf MetricFamily) Collect(row map[string]any, ch chan<- Metric) {
 		value := row[v].(sql.NullFloat64)
 		if value.Valid {
 			metric := NewMetric(&mf, value.Float64, labelValues...)
-			if mf.config.TimeValue == "" {
+			if mf.config.TimestampValue == "" {
 				ch <- metric
 			} else {
-				ts := row[mf.config.TimeValue].(sql.NullTime)
+				ts := row[mf.config.TimestampValue].(sql.NullTime)
 				if ts.Valid {
 					ch <- NewMetricWithTimestamp(ts.Time, metric)
 				}

--- a/metric.go
+++ b/metric.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/burningalchemist/sql_exporter/config"
 	"github.com/burningalchemist/sql_exporter/errors"
@@ -85,7 +86,15 @@ func (mf MetricFamily) Collect(row map[string]any, ch chan<- Metric) {
 		}
 		value := row[v].(sql.NullFloat64)
 		if value.Valid {
-			ch <- NewMetric(&mf, value.Float64, labelValues...)
+			metric := NewMetric(&mf, value.Float64, labelValues...)
+			if mf.config.TimeValue == "" {
+				ch <- metric
+			} else {
+				ts := row[mf.config.TimeValue].(sql.NullTime)
+				if ts.Valid {
+					ch <- NewMetricWithTimestamp(ts.Time, metric)
+				}
+			}
 		}
 	}
 	if mf.config.StaticValue != nil {
@@ -286,3 +295,18 @@ func NewInvalidMetric(err errors.WithContext) Metric {
 func (m invalidMetric) Desc() MetricDesc { return nil }
 
 func (m invalidMetric) Write(*dto.Metric) errors.WithContext { return m.err }
+
+type timestampedMetric struct {
+	Metric
+	t time.Time
+}
+
+func (m timestampedMetric) Write(pb *dto.Metric) errors.WithContext {
+	e := m.Metric.Write(pb)
+	pb.TimestampMs = proto.Int64(m.t.Unix()*1000 + int64(m.t.Nanosecond()/1000000))
+	return e
+}
+
+func NewMetricWithTimestamp(t time.Time, m Metric) Metric {
+	return timestampedMetric{Metric: m, t: t}
+}

--- a/query.go
+++ b/query.go
@@ -50,7 +50,7 @@ func NewQuery(logContext string, qc *config.QueryConfig, metricFamilies ...*Metr
 				return nil, err
 			}
 		}
-		if err := setColumnType(logContext, mf.config.TimeValue, columnTypeTime, columnTypes); err != nil {
+		if err := setColumnType(logContext, mf.config.TimestampValue, columnTypeTime, columnTypes); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
resolves #351

Introduce `timestamp_value` field for the metric configuration. If it points at the column containing a valid timestamp, this timestamp will be collected to return a [metric with a timestamp](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#NewMetricWithTimestamp) such as:

```
test{Username="jenkins46",target="test",test="Identifier"} 4 1328099743000
```