### PR TITLE
fix: if timestamp_value is empty, no need to reserve a column

### DIFF
--- a/query.go
+++ b/query.go
@@ -50,8 +50,10 @@ func NewQuery(logContext string, qc *config.QueryConfig, metricFamilies ...*Metr
 				return nil, err
 			}
 		}
-		if err := setColumnType(logContext, mf.config.TimestampValue, columnTypeTime, columnTypes); err != nil {
-			return nil, err
+		if mf.config.TimestampValue != "" {
+			if err := setColumnType(logContext, mf.config.TimestampValue, columnTypeTime, columnTypes); err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
By default, empty yaml field resolves to empty string, which might create unexpected issues. We want simply check if the field is set, and if not - ignore reserving the column for it.

It's an oversight.