### PR TITLE
docs: Fix PostgreSQL DSN example [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,9 +273,9 @@ jobs:
     collectors: [pricing_data_freshness, pricing_*]
     enable_ping: true # Optional, true by default. Set to `false` in case you connect to pgbouncer or a data warehouse
     static_configs:
-        - targets:
-            pg1: 'pg://db1@127.0.0.1:25432/postgres?sslmode=disable'
-            pg2: 'pg://db2@127.0.0.1:25432/testdb?sslmode=disable'
+      - targets:
+        pg1: 'pg://db1@127.0.0.1:25432/postgres?sslmode=disable'
+        pg2: 'postgresql://username:password@pg-host.example.com:5432/dbname?sslmode=disable'
 ```
 
 , where DSN strings are assigned to the arbitrary instance names (i.e. pg1 and pg2).


### PR DESCRIPTION
Fix DSN example for PostgreSQL db in Readme + fix yaml indentation (2 spaces per level).