### PR TITLE
docs(README): mention the feature of labels for multiple targets in jobs [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ jobs:
       - targets:
           pg1: 'pg://db1@127.0.0.1:25432/postgres?sslmode=disable'
           pg2: 'postgresql://username:password@pg-host.example.com:5432/dbname?sslmode=disable'
+      - labels:  # Optional, arbitrary key/value pair for all targets
+          cluster: cluster1
 ```
 
 , where DSN strings are assigned to the arbitrary instance names (i.e. pg1 and pg2).


### PR DESCRIPTION
We faced some challenges with our team trying to include information in our jobs that had multiple targets, and couldn't use the static_labels in collectors in this specific case.

We were relying on the `job_name`, but it didn't seem like the best approach. After doing some research, we discovered that _sql_exporter_ actually **already** had a feature to address this issue, even though it wasn't documented. 

We've made a small addition to the README to help out any future users who may encounter the same issue as us.