### PR TITLE
fix: update gomod version to fix codeql warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/burningalchemist/sql_exporter
 
-go 1.21
+go 1.21.0
 
-toolchain go1.21.5
+toolchain go1.21.9
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.23.0


### PR DESCRIPTION
CodeQL complains:

> As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).
> 
> 1.21 in go.mod does not match this syntax and there is no additional toolchain directive, which may cause some go commands to fail.