### PR TITLE
fix(build): sync go versions between promu crossbuild and docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Get Go version from the '.promu.yml' config
+        id: promu-go-version
+        run: printf "version=%s" "$(yq '.go.version' .promu.yml)" >> $GITHUB_OUTPUT
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -86,3 +90,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           provenance: false
+          build-args: |
+            GOVERSION={{ steps.promu-go-version.outputs.version }}

--- a/Dockerfile.multi-arch
+++ b/Dockerfile.multi-arch
@@ -1,4 +1,6 @@
-FROM --platform=$BUILDPLATFORM quay.io/prometheus/golang-builder AS builder
+ARG GOVERSION=latest
+
+FROM --platform=$BUILDPLATFORM quay.io/prometheus/golang-builder:${GOVERSION}-main AS builder
 
 # Get sql_exporter
 ADD .   /go/src/github.com/burningalchemist/sql_exporter


### PR DESCRIPTION
To have consistent builds we want to make sure Go version is the same for all the builds. It wasn't a problem before `v1.22`, but it seems to be a good opportunity to improve consistency these days.

## Notable changes

- Update Dockerfile.multi-arch so it takes a build argument (with `latest` being a default value) that we can pick from `.promu.yml`;
- Add a step to GitHub actions to obtain the version from the config file, and store it in the step output key.

## Additional notes

- In the future we might want to drop building binaries again and reuse ones built by promu crossbuild. So the Dockerfile will be changed, the builds also should become faster.