### PR TITLE
fix: indentation of  extra volume mounts in deployment.yaml

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: 0.14.2
 keywords:
   - exporter

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.2](https://img.shields.io/badge/AppVersion-0.14.2-informational?style=flat-square)
+![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.2](https://img.shields.io/badge/AppVersion-0.14.2-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -66,8 +66,8 @@ spec:
             mountPath: /etc/sql_exporter/collectors/
           {{- end }}
           {{- range $v := .Values.extraVolumes }}
-            - name: {{ $v.name }}
-              {{- toYaml $v.mount | nindent 14 }}
+          - name: {{ $v.name }}
+            {{- toYaml $v.mount | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- with .Values.envFrom }}


### PR DESCRIPTION
This was causing an issue where it couldn't properly decode extra volume mounts due to the indentation being out of alignment: 

```
Error: YAML parse error on sql-exporter/templates/deployment.yaml: error converting YAML to JSON: yaml: line 48: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 48: did not find expected key
```

