### PR TITLE
feat(helm): Sidecar and Service Account Update

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.4.5
+version: 0.4.6
 appVersion: 0.14.2
 keywords:
   - exporter

--- a/helm/README.md
+++ b/helm/README.md
@@ -39,6 +39,9 @@ helm install sql_exporter/sql-exporter
 | service.port | int | `80` | Service port |
 | service.labels | object | `{}` | Service labels |
 | service.annotations | object | `{}` | Service annotations |
+| extraContainers | object | `{}` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.annotations | object | `{}` |  |
 | resources | object | `{}` | Resource limits and requests for the application controller pods |
 | podLabels | object | `{}` | Pod labels |
 | podAnnotations | object | `{}` | Pod annotations |

--- a/helm/README.md
+++ b/helm/README.md
@@ -42,6 +42,8 @@ helm install sql_exporter/sql-exporter
 | extraContainers | object | `{}` |  |
 | serviceAccount.create | bool | `false` |  |
 | serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.name | string | `""` |  |
+| serviceAccount.automountServiceAccountToken | bool | `false` |  |
 | resources | object | `{}` | Resource limits and requests for the application controller pods |
 | podLabels | object | `{}` | Pod labels |
 | podAnnotations | object | `{}` | Pod annotations |

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -51,13 +51,22 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Determine if service account needs to be created
+*/}}
+{{- define "sql-exporter.createServiceAccount" -}}
+{{- with .Values.serviceAccount }}
+{{- default "false" .create }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "sql-exporter.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if (include "sql-exporter.createServiceAccount" . ) }}
 {{- default (include "sql-exporter.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- "default" }}
 {{- end }}
 {{- end }}
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -29,8 +29,8 @@ spec:
     {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if eq (include "sql-exporter.volumes" .)  "\"true\"" }}
       serviceAccount: {{ default "default" .Values.serviceAccount.name }}
+      {{- if eq (include "sql-exporter.volumes" .)  "\"true\"" }}
       volumes:
         {{- if .Values.createConfig }}
         - name: sql-exporter
@@ -109,9 +109,9 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-{{- with .Values.extraContainers }}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- with .Values.extraContainers }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      serviceAccount: {{ default "default" .Values.serviceAccount.name }}
+      serviceAccount: {{ include "sql-exporter.serviceAccountName" . }}
       {{- if eq (include "sql-exporter.volumes" .)  "\"true\"" }}
       volumes:
         {{- if .Values.createConfig }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if eq (include "sql-exporter.volumes" .)  "\"true\"" }}
+      serviceAccount: {{ default "default" .Values.serviceAccount.name }}
       volumes:
         {{- if .Values.createConfig }}
         - name: sql-exporter
@@ -108,6 +109,9 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+{{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount -}}
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,13 +1,9 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}
-  {{- with .Values.serviceAccount.labels }}
-  labels:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with .Values.serviceAccount.annotations }}
+  name: {{ include "sql-exporter.serviceAccountName" . }}
+  {{- with .Values.serviceAccount.annotations}}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -7,4 +7,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  labels:
+    {{- with .Values.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- include "sql-exporter.labels" . | nindent 4 }}
+automountServiceAccountToken: {{ default "false" .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create }}
+{{- if (include "sql-exporter.createServiceAccount" . ) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  {{- with .Values.serviceAccount.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,5 +1,6 @@
 # -- Provide a name in place of `sql-exporter`
 nameOverride: ""
+
 # -- String to fully override "sql-exporter.fullname"
 fullnameOverride: ""
 
@@ -14,6 +15,7 @@ image:
 
 # -- Secrets with credentials to pull images from a private registry
 imagePullSecrets: []
+
 service:
   # -- Service type
   type: ClusterIP
@@ -26,13 +28,13 @@ service:
     # example of prometheus usage
     # prometheus.io/scrape: "true"
     # prometheus.io/path: "/metrics"
+
 extraContainers: {}
 #   - name: your_sidecar 
 #     image: gcr.io/your_image:your_tag
 #     args:
 #     resources:
 #       requests:{}
-
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -42,9 +44,9 @@ serviceAccount:
   ## example annotations ##
   # annotations:
   #   iam.gke.io/gcp-service-account: my-service-account@gke.url
+  name: ""
+  automountServiceAccountToken: false
 
-  # name: "my_kubernetes_sa"
-  # automountServiceAccountToken: false
 # -- Resource limits and requests for the application controller pods
 resources: {}
   # limits:
@@ -56,6 +58,7 @@ resources: {}
 
 # -- Pod labels
 podLabels: {}
+
 # -- Pod annotations
 podAnnotations: {}
 
@@ -67,6 +70,7 @@ podSecurityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+
 # @ignored
 securityContext: {}
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -30,7 +30,7 @@ service:
     # prometheus.io/path: "/metrics"
 
 extraContainers: {}
-#   - name: your_sidecar 
+#   - name: your_sidecar
 #     image: gcr.io/your_image:your_tag
 #     args:
 #     resources:
@@ -179,3 +179,4 @@ config:
 #           SELECT Market, max(UpdateTime) AS LastUpdateTime
 #           FROM MarketPrices
 #           GROUP BY Market
+

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -42,9 +42,9 @@ serviceAccount:
   ## example annotations ##
   # annotations:
   #   iam.gke.io/gcp-service-account: my-service-account@gke.url
-  #
-  # name: "my_kubernetes_sa"
 
+  # name: "my_kubernetes_sa"
+  # automountServiceAccountToken: false
 # -- Resource limits and requests for the application controller pods
 resources: {}
   # limits:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -22,66 +22,30 @@ service:
   # -- Service labels
   labels: {}
   # -- Service annotations
-  annotations:
-    {}
+  annotations: {}
     # example of prometheus usage
     # prometheus.io/scrape: "true"
     # prometheus.io/path: "/metrics"
-extraContainers:
-  - name: cloud-sql-proxy
-    image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8-alpine
-    args:
-      # Enables Automatic IAM Authentication for all instances
-      - "--auto-iam-authn"
-      # Enable structured logging with LogEntry format:
-      - "--structured-logs"
-      # Debug flag
-      - "--debug"
-      # If connecting from a VPC-native GKE cluster, use the
-      # following flag to have the proxy connect over private IP
-      - "--private-ip"
-      # Enable the admin api server on port 9091
-      - "--admin-port=9091"
-      # Enable the /quitquitquit admin api endpoint for non-root SIGTERM
-      - "--quitquitquit"
-      # Tell the proxy to exit gracefully if it receives a SIGTERM
-      - "--exit-zero-on-sigterm"
-      # Replace DB_PORT with the port the proxy should listen on
-      - "--port=5432"
-      # Replace with the DB connection name
-      - "xpanse-pre-aw-svc-asset-inv:us-central1:expander-api-db-fr-dev"
-    securityContext:
-      # The default Cloud SQL proxy image runs as the
-      # "nonroot" user and group (uid: 65532) by default.
-      runAsNonRoot: false
-    # Resource configuration depends on an application's requirements. You
-    # should adjust the following values based on what your application
-    # needs. For details, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-    resources:
-      requests:
-        # The proxy's memory use scales linearly with the number of active
-        # connections. Fewer open connections will use less memory. Adjust
-        # this value based on your application's requirements.
-        memory: "2Gi"
-        # The proxy's CPU use scales linearly with the amount of IO between
-        # the database and the application. Adjust this value based on your
-        # application's requirements.
-        cpu:    "1"
+extraContainers: {}
+#   - name: your_sidecar 
+#     image: gcr.io/your_image:your_tag
+#     args:
+#     resources:
+#       requests:{}
 
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: true
+  create: false
   # Annotations to add to the service account
-  annotations:
-    iam.gke.io/gcp-service-account: "tenant-service-db-user@xpanse-pre-aw-svc-asset-inv.iam.gserviceaccount.com"
+  annotations: {}
 
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: "db-proxy"
+  # name: "my_sa"
 
 #  name: "my_kubernetes_sa"
-# Example Annotations
+#  Example Annotations
 #  annotations: {
 #    iam.gke.io/gcp-service-account: my-service-account@gke.url
 #  }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,9 +1,7 @@
 # -- Provide a name in place of `sql-exporter`
 nameOverride: ""
-
 # -- String to fully override "sql-exporter.fullname"
 fullnameOverride: ""
-
 image:
   # -- Image repository
   repository: burningalchemist/sql_exporter
@@ -12,10 +10,8 @@ image:
   # -- Image tag
   # @default -- `appVersion` value from `Chart.yaml`
   tag: ""
-
 # -- Secrets with credentials to pull images from a private registry
 imagePullSecrets: []
-
 service:
   # -- Service type
   type: ClusterIP
@@ -28,14 +24,12 @@ service:
     # example of prometheus usage
     # prometheus.io/scrape: "true"
     # prometheus.io/path: "/metrics"
-
 extraContainers: {}
 #   - name: your_sidecar
 #     image: gcr.io/your_image:your_tag
 #     args:
 #     resources:
 #       requests:{}
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: false
@@ -46,7 +40,6 @@ serviceAccount:
   #   iam.gke.io/gcp-service-account: my-service-account@gke.url
   name: ""
   automountServiceAccountToken: false
-
 # -- Resource limits and requests for the application controller pods
 resources: {}
   # limits:
@@ -55,13 +48,10 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
-
 # -- Pod labels
 podLabels: {}
-
 # -- Pod annotations
 podAnnotations: {}
-
 # -- Pod security context
 podSecurityContext: {}
   # capabilities:
@@ -70,10 +60,8 @@ podSecurityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
-
 # @ignored
 securityContext: {}
-
 # Prometheus Operator values
 serviceMonitor:
   # -- Enable ServiceMonitor
@@ -86,7 +74,6 @@ serviceMonitor:
   # scrapeTimeout: 10s
   # -- ServiceMonitor metric relabelings
   metricRelabelings: {}
-
 # Additional env variables
 # - kind should be either Secret or ConfigMap
 # - name is the name of the Secret or ConfigMap that should be used
@@ -179,4 +166,3 @@ config:
 #           SELECT Market, max(UpdateTime) AS LastUpdateTime
 #           FROM MarketPrices
 #           GROUP BY Market
-

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -14,7 +14,6 @@ image:
 
 # -- Secrets with credentials to pull images from a private registry
 imagePullSecrets: []
-
 service:
   # -- Service type
   type: ClusterIP
@@ -28,10 +27,67 @@ service:
     # example of prometheus usage
     # prometheus.io/scrape: "true"
     # prometheus.io/path: "/metrics"
+extraContainers:
+  - name: cloud-sql-proxy
+    image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8-alpine
+    args:
+      # Enables Automatic IAM Authentication for all instances
+      - "--auto-iam-authn"
+      # Enable structured logging with LogEntry format:
+      - "--structured-logs"
+      # Debug flag
+      - "--debug"
+      # If connecting from a VPC-native GKE cluster, use the
+      # following flag to have the proxy connect over private IP
+      - "--private-ip"
+      # Enable the admin api server on port 9091
+      - "--admin-port=9091"
+      # Enable the /quitquitquit admin api endpoint for non-root SIGTERM
+      - "--quitquitquit"
+      # Tell the proxy to exit gracefully if it receives a SIGTERM
+      - "--exit-zero-on-sigterm"
+      # Replace DB_PORT with the port the proxy should listen on
+      - "--port=5432"
+      # Replace with the DB connection name
+      - "xpanse-pre-aw-svc-asset-inv:us-central1:expander-api-db-fr-dev"
+    securityContext:
+      # The default Cloud SQL proxy image runs as the
+      # "nonroot" user and group (uid: 65532) by default.
+      runAsNonRoot: false
+    # Resource configuration depends on an application's requirements. You
+    # should adjust the following values based on what your application
+    # needs. For details, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    resources:
+      requests:
+        # The proxy's memory use scales linearly with the number of active
+        # connections. Fewer open connections will use less memory. Adjust
+        # this value based on your application's requirements.
+        memory: "2Gi"
+        # The proxy's CPU use scales linearly with the amount of IO between
+        # the database and the application. Adjust this value based on your
+        # application's requirements.
+        cpu:    "1"
+
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations:
+    iam.gke.io/gcp-service-account: "tenant-service-db-user@xpanse-pre-aw-svc-asset-inv.iam.gserviceaccount.com"
+
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "db-proxy"
+
+#  name: "my_kubernetes_sa"
+# Example Annotations
+#  annotations: {
+#    iam.gke.io/gcp-service-account: my-service-account@gke.url
+#  }
 
 # -- Resource limits and requests for the application controller pods
-resources:
-  {}
+resources: {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -45,8 +101,7 @@ podLabels: {}
 podAnnotations: {}
 
 # -- Pod security context
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # capabilities:
   #   drop:
   #   - ALL

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -39,16 +39,11 @@ serviceAccount:
   create: false
   # Annotations to add to the service account
   annotations: {}
-
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  # name: "my_sa"
-
-#  name: "my_kubernetes_sa"
-#  Example Annotations
-#  annotations: {
-#    iam.gke.io/gcp-service-account: my-service-account@gke.url
-#  }
+  ## example annotations ##
+  # annotations:
+  #   iam.gke.io/gcp-service-account: my-service-account@gke.url
+  #
+  # name: "my_kubernetes_sa"
 
 # -- Resource limits and requests for the application controller pods
 resources: {}


### PR DESCRIPTION
Enable extra containers and service account customization  to facilitate running a sql auth proxy as a sidecar.  The service account customization was necessary to enable alternative authentication methods such as workload identity.

Please squash when merging.  