### PR TITLE
fix!(helm): adjust the logic for serviceAccount creation

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.4.6
-appVersion: 0.14.2
+version: 0.5.0
+appVersion: 0.14.3
 keywords:
   - exporter
   - servicemonitor

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.2](https://img.shields.io/badge/AppVersion-0.14.2-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.3](https://img.shields.io/badge/AppVersion-0.14.3-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 
@@ -39,11 +39,9 @@ helm install sql_exporter/sql-exporter
 | service.port | int | `80` | Service port |
 | service.labels | object | `{}` | Service labels |
 | service.annotations | object | `{}` | Service annotations |
-| extraContainers | object | `{}` |  |
-| serviceAccount.create | bool | `false` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.name | string | `""` |  |
-| serviceAccount.automountServiceAccountToken | bool | `false` |  |
+| extraContainers | object | `{}` | Arbitrary sidecar containers list |
+| serviceAccount.create | bool | `true` | Specifies whether a Service Account should be created, defaults to "sql-exporter" unless overriden. Check values.yaml for all the available parameters |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the Service Account |
 | resources | object | `{}` | Resource limits and requests for the application controller pods |
 | podLabels | object | `{}` | Pod labels |
 | podAnnotations | object | `{}` | Pod annotations |

--- a/helm/README.md.gotmpl
+++ b/helm/README.md.gotmpl
@@ -33,6 +33,7 @@ helm install sql_exporter/sql-exporter
   {{- end }}
 {{- end }}
 
+
 ### Prometheus ServiceMonitor
 
 | Key | Type | Default | Description |

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -51,23 +51,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Determine if service account needs to be created
-*/}}
-{{- define "sql-exporter.createServiceAccount" -}}
-{{- with .Values.serviceAccount }}
-{{- default "false" .create }}
-{{- end }}
-{{- end }}
-
-{{/*
 Create the name of the service account to use
 */}}
 {{- define "sql-exporter.serviceAccountName" -}}
-{{- if (include "sql-exporter.createServiceAccount" . ) }}
-{{- default (include "sql-exporter.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- "default" }}
-{{- end }}
+{{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 
 {{- define "sql-exporter.volumes" -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      serviceAccount: {{ include "sql-exporter.serviceAccountName" . }}
+      serviceAccountName: {{ if .Values.serviceAccount.create }}{{ template "sql-exporter.fullname" . }}{{ else }}{{ include "sql-exporter.serviceAccountName" . }}{{end}}
       {{- if eq (include "sql-exporter.volumes" .)  "\"true\"" }}
       volumes:
         {{- if .Values.createConfig }}

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,8 +1,8 @@
-{{- if (include "sql-exporter.createServiceAccount" . ) }}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "sql-exporter.serviceAccountName" . }}
+  name: {{ template "sql-exporter.fullname" . }}
   {{- with .Values.serviceAccount.annotations}}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -32,10 +32,10 @@ extraContainers: {}
 #     resources:
 #       requests:{}
 serviceAccount:
-  # -- Specifies whether a Service Account should be created, set to "sql-exporter" if true, unless overriden.
-  # Otherwise, set to `default` if false, and custom service account name is not provided. Check all the available
-  # parameters.
-  create: false
+  # -- Specifies whether a Service Account should be created, creates "sql-exporter" service account if true, unless
+  # overriden. Otherwise, set to `default` if false, and custom service account name is not provided. Check all the
+  # available parameters.
+  create: true
   # -- References a custom Service Account if it already exists
   # name: "sql-exporter-custom-sa"
   # -- Annotations to add to the Service Account

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -24,6 +24,7 @@ service:
     # example of prometheus usage
     # prometheus.io/scrape: "true"
     # prometheus.io/path: "/metrics"
+# -- Arbitrary sidecar containers list
 extraContainers: {}
 #   - name: your_sidecar
 #     image: gcr.io/your_image:your_tag
@@ -31,15 +32,19 @@ extraContainers: {}
 #     resources:
 #       requests:{}
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a Service Account should be created, set to "sql-exporter" if true, unless overriden.
+  # Otherwise, set to `default` if false, and custom service account name is not provided. Check all the available
+  # parameters.
   create: false
-  # Annotations to add to the service account
+  # -- References a custom Service Account if it already exists
+  # name: "sql-exporter-custom-sa"
+  # -- Annotations to add to the Service Account
   annotations: {}
   ## example annotations ##
   # annotations:
   #   iam.gke.io/gcp-service-account: my-service-account@gke.url
-  name: ""
-  automountServiceAccountToken: false
+  # -- Defines if token is automatically mounted to the pod after it has been created
+  # automountServiceAccountToken: false
 # -- Resource limits and requests for the application controller pods
 resources: {}
   # limits:


### PR DESCRIPTION
- `serviceAccount` field is deprecated in favour of `serviceAccountName`;
- `serviceAccount.create` should create a serviceAccount resource bound to the helm release name (which can be overriden, yet is consistent);
- `serviceAccount.name` should allow users to reference a custom service account created outside of the helm release;
- if `create` is false, and name is not set, `serviceAccountName` field falls back to `default` which is equal to not providing the `serviceAccountName` at all.

BREAKING CHANGE: from v0.5.0 serviceAccount `sql-exporter` is created by default. Can be disabled if needed to reference a custom serviceAccount object.