### PR TITLE
docs: Update Readme and Doc [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.vscode
 /sql_exporter
 /sql_exporter.yml
+.idea/*

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Use the `-help` flag to get help information.
 $ ./sql_exporter -help
 Usage of ./sql_exporter:
   -config.file string
-      SQL Exporter configuration file name. (default "sql_exporter.yml")
+      SQL Exporter configuration file path. (default "sql_exporter.yml")
   -web.listen-address string
       Address to listen on for web interface and telemetry. (default ":9399")
   -web.metrics-path string

--- a/documentation/sql_exporter.yml
+++ b/documentation/sql_exporter.yml
@@ -59,9 +59,9 @@ collectors:
     # The result columns conceptually fall into two categories:
     #  * zero or more key columns: their values will be directly mapped to labels of the same name;
     #  * one or more value columns:
-    #     * if exactly one value column, the column name name is ignored and its value becomes the metric value
+    #     * if exactly one value column, the column name is ignored and its value becomes the metric value
     #     * with multiple value columns, a `value_label` must be defined; the column name will populate this label and
-    #       the column value will popilate the metric value.
+    #       the column value will populate the metric value.
     metrics:
       # The metric name, type and help text, as exported to /metrics.
       - metric_name: mssql_log_growths
@@ -97,7 +97,7 @@ collectors:
         #
         # Required when multiple value columns are configured.
         value_label: operation
-        # Multiple value columns: their name is recorded in the label defined by `attrubute_label` (e.g. 
+        # Multiple value columns: their name is recorded in the label defined by `attribute_label` (e.g.
         # `operation="io_stall_read_ms"`).
         values:
           - io_stall_read


### PR DESCRIPTION
Fix the explanation of the argument -config.file string
      SQL Exporter configuration file name. (default "sql_exporter.yml")
      
It should be: SQL Exporter configuration file path. (default "sql_exporter.yml")

And some typos. 