### PR TITLE
build: disable symbol table, DWARF generation for builds

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -14,6 +14,8 @@ build:
       -X github.com/prometheus/common/version.Branch={{.Branch}}
       -X github.com/prometheus/common/version.BuildUser={{user}}@{{host}}
       -X github.com/prometheus/common/version.BuildDate={{date "20060102-15:04:05"}}
+      -s
+      -w
 tarball:
     files:
       - LICENSE


### PR DESCRIPTION
Effectively, to shrink the binary size.