### PR TITLE
fix(helm): ServiceMonitor namespace override

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: 0.15.0
 keywords:
   - exporter

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.0](https://img.shields.io/badge/AppVersion-0.15.0-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.0](https://img.shields.io/badge/AppVersion-0.15.0-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 
@@ -54,9 +54,9 @@ helm install sql_exporter/sql-exporter
 |-----|------|---------|-------------|
 | serviceMonitor.enabled | bool | `true` | Enable ServiceMonitor |
 | serviceMonitor.interval | string | `"15s"` | ServiceMonitor interval |
-| serviceMonitor.namespace | string | `{{ .Release.Namespace }}` | override for the namespace where the ServiceMonitor will be deployed |
 | serviceMonitor.path | string | `"/metrics"` | ServiceMonitor path |
 | serviceMonitor.metricRelabelings | object | `{}` | ServiceMonitor metric relabelings |
+| serviceMonitor.namespace | string | `nil` | ServiceMonitor namespace override (default is .Release.Namespace) |
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout |
 
 ### Configuration

--- a/helm/README.md
+++ b/helm/README.md
@@ -54,6 +54,7 @@ helm install sql_exporter/sql-exporter
 |-----|------|---------|-------------|
 | serviceMonitor.enabled | bool | `true` | Enable ServiceMonitor |
 | serviceMonitor.interval | string | `"15s"` | ServiceMonitor interval |
+| serviceMonitor.namespace | string | `{{ .Release.Namespace }}` | override for the namespace where the ServiceMonitor will be deployed |
 | serviceMonitor.path | string | `"/metrics"` | ServiceMonitor path |
 | serviceMonitor.metricRelabelings | object | `{}` | ServiceMonitor metric relabelings |
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout |

--- a/helm/templates/servicemonitor.yaml
+++ b/helm/templates/servicemonitor.yaml
@@ -34,5 +34,9 @@ spec:
       {{- end }}
   namespaceSelector:
     matchNames:
+    {{- if .Values.serviceMonitor.namespace }}
+    - {{ .Values.serviceMonitor.namespace }}
+    {{- else }}
     - {{ .Release.Namespace }}
+    {{- end }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -79,6 +79,8 @@ serviceMonitor:
   # scrapeTimeout: 10s
   # -- ServiceMonitor metric relabelings
   metricRelabelings: {}
+  # -- ServiceMonitor namespace override (default is .Release.Namespace)
+  namespace: ~
 # Additional env variables
 # - kind should be either Secret or ConfigMap
 # - name is the name of the Secret or ConfigMap that should be used


### PR DESCRIPTION
if I set `serviceMonitor.namespace`, it overrides the namespace where the ServiceMonitor is deployed. However, the pod is deployed in the same namespace, so I'd like this to override the namespace in `matchNamespace` spec field also. 