### PR TITLE
docs: update data_source_name in configuration file

### DIFF
--- a/documentation/sql_exporter.yml
+++ b/documentation/sql_exporter.yml
@@ -35,7 +35,7 @@ target:
   name: mssql_database
   # Data source name always has a URI schema that matches the driver name. In some cases (e.g. MySQL)
   # the schema gets dropped or replaced to match the driver expected DSN format.
-  data_source_name: 'sqlserver://prom_user:prom_password@dbserver1.example.com:1433'
+  data_source_name: 'sqlserver://prom_user:prom_password@dbserver1.example.com:1433/dbname'
 
   # Collectors (referenced by name) to execute on the target.
   collectors: [mssql_standard]

--- a/examples/sql_exporter.yml
+++ b/examples/sql_exporter.yml
@@ -20,7 +20,7 @@ global:
 target:
   # Data source name always has a URI schema that matches the driver name. In some cases (e.g. MySQL)
   # the schema gets dropped or replaced to match the driver expected DSN format.
-  data_source_name: 'sqlserver://prom_user:prom_password@dbserver1.example.com:1433'
+  data_source_name: 'sqlserver://prom_user:prom_password@dbserver1.example.com:1433/dbname'
 
   # Collectors (referenced by name) to execute on the target.
   # Glob patterns are supported (see <https://pkg.go.dev/path/filepath#Match> for syntax).


### PR DESCRIPTION
Getting invalid URL error because of this. Found the solution in `https://github.com/xo/dburl` documentation.   
The example database connection URL that can be handled by `dburl.Parse` and `dburl.Open`:
`sqlserver://user:pass@remote-host.com/dbname`

I think we need to provide dbname in data_source_name
