### PR TITLE
Add Oracle DB driver in extra + fix make build for arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ promu:
 else
 promu:
 	@GOOS=$(shell uname -s | tr A-Z a-z) \
-		GOARCH=$(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m))) \
+		GOARCH=$(subst x86_64,amd64,$(subst aarch64,arm64,$(patsubst i%86,386,$(shell uname -m)))) \
 		$(GO) install github.com/prometheus/promu@$(PROMU_VERSION)
 endif
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ monitoring system. Out of the box, it provides support for the following databas
 - Clickhouse
 - Snowflake
 - Vertica
+- Oracle DB
 
 In fact, any DBMS for which a Go driver is available may be monitored after rebuilding the binary with the DBMS driver
 included.

--- a/drivers.go
+++ b/drivers.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "github.com/lib/pq"
 	_ "github.com/microsoft/go-mssqldb/azuread"
+	_ "github.com/sijms/go-ora/v2"
 	_ "github.com/snowflakedb/gosnowflake"
 	_ "github.com/vertica/vertica-sql-go"
 )

--- a/drivers_gen.go
+++ b/drivers_gen.go
@@ -25,6 +25,7 @@ var driverList = map[string][]string{
 		"github.com/jackc/pgx/v5/stdlib",
 		"github.com/snowflakedb/gosnowflake",
 		"github.com/vertica/vertica-sql-go",
+		"github.com/sijms/go-ora/v2",
 	},
 	"custom": {
 		"github.com/mithrandie/csvq-driver",

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/prometheus/common v0.55.0
 	github.com/prometheus/exporter-toolkit v0.11.0
 	github.com/sethvargo/go-envconfig v1.1.0
+	github.com/sijms/go-ora/v2 v2.8.19
 	github.com/snowflakedb/gosnowflake v1.11.0
 	github.com/vertica/vertica-sql-go v1.3.3
 	github.com/xo/dburl v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,8 @@ github.com/sethvargo/go-envconfig v1.1.0 h1:cWZiJxeTm7AlCvzGXrEXaSTCNgip5oJepekh
 github.com/sethvargo/go-envconfig v1.1.0/go.mod h1:JLd0KFWQYzyENqnEPWWZ49i4vzZo/6nRidxI8YvGiHw=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
+github.com/sijms/go-ora/v2 v2.8.19 h1:7LoKZatDYGi18mkpQTR/gQvG9yOdtc7hPAex96Bqisc=
+github.com/sijms/go-ora/v2 v2.8.19/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
 github.com/simonpasquier/klog-gokit/v3 v3.4.0 h1:2eD2INbzUHuGNynPP86BCB8H6Lwfp6wlkOcuyTr3VWM=
 github.com/simonpasquier/klog-gokit/v3 v3.4.0/go.mod h1:RREVB5Cc6yYHsweRfhUyM1ZP+Odb8ehxLfY8jaiqvjg=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=


### PR DESCRIPTION
Hi burningalchemist

I know that this exporter is agnostic and can support different kind of drivers as you mentioned here
https://github.com/burningalchemist/sql_exporter/issues/207

Still it would be very valuable to have the Oracle DB off the shelf as it is in the TOP 5 of the DB market. It would be appealing for many people...
I have being using [Corundex](https://github.com/Corundex/database_exporter) and [Free Exporter](https://github.com/free/sql_exporter) with Oracle DB driver (godror) for more than 5 years now, and it worked pretty well.
Those exporters are not maintained so I decided to switch to yours which contains many refactoring which is all good.

I would be happy to contribute to your project and test every new release in an Oracle DB context.

Regards
Arnaud