### PR TITLE
feat(helm): configure liveness and readiness probes

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.6.1
+version: 0.6.2
 appVersion: 0.15.0
 keywords:
   - exporter

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.6.2
+version: 0.7.0
 appVersion: 0.15.0
 keywords:
   - exporter

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.0](https://img.shields.io/badge/AppVersion-0.15.0-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.15.0](https://img.shields.io/badge/AppVersion-0.15.0-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 
@@ -42,6 +42,10 @@ helm install sql_exporter/sql-exporter
 | extraContainers | object | `{}` | Arbitrary sidecar containers list |
 | serviceAccount.create | bool | `true` | Specifies whether a Service Account should be created, creates "sql-exporter" service account if true, unless overriden. Otherwise, set to `default` if false, and custom service account name is not provided. Check all the available parameters. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the Service Account |
+| livenessProbe.initialDelaySeconds | int | `5` |  |
+| livenessProbe.timeoutSeconds | int | `30` |  |
+| readinessProbe.initialDelaySeconds | int | `5` |  |
+| readinessProbe.timeoutSeconds | int | `30` |  |
 | resources | object | `{}` | Resource limits and requests for the application controller pods |
 | podLabels | object | `{}` | Pod labels |
 | podAnnotations | object | `{}` | Pod annotations |

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -104,6 +104,8 @@ spec:
           readinessProbe:
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            httpGet:
+              path: /healthz
               port: 9399
           ports:
             - name: http

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -96,12 +96,14 @@ spec:
             {{- end }}
             {{- end }}
           livenessProbe:
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             httpGet:
               path: /healthz
               port: 9399
           readinessProbe:
-            httpGet:
-              path: /healthz
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
               port: 9399
           ports:
             - name: http

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -45,6 +45,14 @@ serviceAccount:
   #   iam.gke.io/gcp-service-account: my-service-account@gke.url
   # -- Defines if token is automatically mounted to the pod after it has been created
   # automountServiceAccountToken: false
+# Liveness and readiness probes for the application controller pods
+livenessProbe:
+  initialDelaySeconds: 5
+  timeoutSeconds: 30
+
+readinessProbe:
+  initialDelaySeconds: 5
+  timeoutSeconds: 30
 # -- Resource limits and requests for the application controller pods
 resources: {}
   # limits:


### PR DESCRIPTION
- Allow configuration of liveness and readiness probes
- Defaults might be too stringent in certain environments causing unnecessary pod restarts