### PR TITLE
refactor: remove deprecated --log.json flag

### DIFF
--- a/cmd/sql_exporter/main.go
+++ b/cmd/sql_exporter/main.go
@@ -38,7 +38,6 @@ var (
 	enableReload  = flag.Bool("web.enable-reload", false, "Enable reload collector data handler")
 	webConfigFile = flag.String("web.config.file", "", "[EXPERIMENTAL] TLS/BasicAuth configuration file path")
 	configFile    = flag.String("config.file", "sql_exporter.yml", "SQL Exporter configuration file path")
-	logFormatJSON = flag.Bool("log.json", false, "[DEPRECATED] Set log output format to JSON")
 	logFormat     = flag.String("log.format", "logfmt", "Set log output format")
 	logLevel      = flag.String("log.level", "info", "Set log level")
 )
@@ -66,7 +65,7 @@ func main() {
 	}
 
 	// Setup logging.
-	logger, err := setupLogging(*logLevel, *logFormat, *logFormatJSON)
+	logger, err := setupLogging(*logLevel, *logFormat)
 	if err != nil {
 		fmt.Printf("Error initializing exporter: %s\n", err)
 		os.Exit(1)
@@ -152,7 +151,7 @@ func startScrapeErrorsDropTicker(exporter sql_exporter.Exporter, interval model.
 }
 
 // setupLogging configures and initializes the logging system.
-func setupLogging(logLevel, logFormat string, logFormatJSON bool) (log.Logger, error) {
+func setupLogging(logLevel, logFormat string) (log.Logger, error) {
 	promlogConfig := &promlog.Config{
 		Level:  &promlog.AllowedLevel{},
 		Format: &promlog.AllowedFormat{},
@@ -162,13 +161,7 @@ func setupLogging(logLevel, logFormat string, logFormatJSON bool) (log.Logger, e
 		return nil, err
 	}
 
-	// Override log format if JSON is specified.
-	finalLogFormat := logFormat
-	if logFormatJSON {
-		fmt.Print("Warning: The flag --log.json is deprecated and will be removed in a future release. Please use --log.format=json instead\n")
-		finalLogFormat = "json"
-	}
-	if err := promlogConfig.Format.Set(finalLogFormat); err != nil {
+	if err := promlogConfig.Format.Set(logFormat); err != nil {
 		return nil, err
 	}
 	// Overriding the default klog with our go-kit klog implementation.


### PR DESCRIPTION
This pull request includes removing the deprecated `log.json` flag and updating the `setupLogging` function accordingly.

Now the only possible way to set up the log format is by using `--log.format` parameter with `logfmt` or `json` as allowed values.