### PR TITLE
build(promu): set go version to 1.23

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,6 @@
 go:
     cgo: false
-    version: 1.21
+    version: 1.23
 repository:
     path: github.com/burningalchemist/sql_exporter
 build:


### PR DESCRIPTION
This pull request includes a minor update to the `.promu.yml` configuration file, specifically updating the Go language version.

* [`.promu.yml`](diffhunk://#diff-76a63a7d40d9c5b7f57eed5b30dd49aaa623ad3d151a7846ffeca93f08db0eb8L3-R3): Updated the Go version from `1.21` to `1.23`.