### PR TITLE
fix(packaging): update -log.format parameter for deb/rpm config

### DIFF
--- a/packaging/conf/sql_exporter.default
+++ b/packaging/conf/sql_exporter.default
@@ -1,6 +1,6 @@
 CONF_FILE=/etc/sql_exporter/sql_exporter.yml
 LISTEN_ADDRESS=0.0.0.0:9399
-LOG_JSON=false
+LOG_FORMAT=logfmt
 LOG_LEVEL=debug
 ENABLE_RELOAD=false
 METRICS_PATH=/metrics

--- a/packaging/deb/sql_exporter.service
+++ b/packaging/deb/sql_exporter.service
@@ -13,7 +13,7 @@ Restart=on-failure
 WorkingDirectory=/usr/share/sql_exporter
 RuntimeDirectory=sql_exporter
 RuntimeDirectoryMode=0750
-ExecStart=/usr/bin/sql_exporter -config.file=${CONF_FILE} -web.listen-address=${LISTEN_ADDRESS} -log.json=${LOG_JSON} -log.level=${LOG_LEVEL} -web.enable-reload=${ENABLE_RELOAD} -web.metrics-path=${METRICS_PATH} -web.config.file=${WEB_CONFIG_FILE}
+ExecStart=/usr/bin/sql_exporter -config.file=${CONF_FILE} -web.listen-address=${LISTEN_ADDRESS} -log.format=${LOG_FORMAT} -log.level=${LOG_LEVEL} -web.enable-reload=${ENABLE_RELOAD} -web.metrics-path=${METRICS_PATH} -web.config.file=${WEB_CONFIG_FILE}
 LimitNOFILE=10000
 TimeoutStopSec=20
 CapabilityBoundingSet=

--- a/packaging/rpm/sql_exporter.service
+++ b/packaging/rpm/sql_exporter.service
@@ -13,7 +13,7 @@ Restart=on-failure
 WorkingDirectory=/usr/share/sql_exporter
 RuntimeDirectory=sql_exporter
 RuntimeDirectoryMode=0750
-ExecStart=/usr/bin/sql_exporter -config.file=${CONF_FILE} -web.listen-address=${LISTEN_ADDRESS} -log.json=${LOG_JSON} -log.level=${LOG_LEVEL} -web.enable-reload=${ENABLE_RELOAD} -web.metrics-path=${METRICS_PATH} -web.config.file=${WEB_CONFIG_FILE}
+ExecStart=/usr/bin/sql_exporter -config.file=${CONF_FILE} -web.listen-address=${LISTEN_ADDRESS} -log.format=${LOG_FORMAT} -log.level=${LOG_LEVEL} -web.enable-reload=${ENABLE_RELOAD} -web.metrics-path=${METRICS_PATH} -web.config.file=${WEB_CONFIG_FILE}
 LimitNOFILE=10000
 TimeoutStopSec=20
 CapabilityBoundingSet=


### PR DESCRIPTION
This pull request includes changes to the logging configuration for the SQL Exporter service. The primary update is the switch from JSON logging to logfmt format across different configuration files.

Logging configuration changes:

* [`packaging/conf/sql_exporter.default`](diffhunk://#diff-ad3e6f08166545f5de24ef29da8a44dde44e9369144a888e15bc9b762393aa46L3-R3): Changed `LOG_JSON=false` to `LOG_FORMAT=logfmt` to update the logging format.
* [`packaging/deb/sql_exporter.service`](diffhunk://#diff-487da9683d07d225f3b70cab8f4acd6bdb657bddd5c362840b7b983143a3d52dL16-R16): Updated `ExecStart` command to use `-log.format=${LOG_FORMAT}` instead of `-log.json=${LOG_JSON}` for the Debian service configuration.
* [`packaging/rpm/sql_exporter.service`](diffhunk://#diff-6c612085e57c7935f6a670f78dc129cc46baf920ed3a04de5e540b18e27c1211L16-R16): Updated `ExecStart` command to use `-log.format=${LOG_FORMAT}` instead of `-log.json=${LOG_JSON}` for the RPM service configuration.