### PR TITLE
fix(gomod): follow 1.N.P syntax

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/burningalchemist/sql_exporter
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.30.0


### PR DESCRIPTION
CodeQL complains about go.mod file, as it doesn't follow the new syntax (https://go.dev/doc/toolchain#version)