### PR TITLE
fix: add query execution duration as debug msg

### DIFF
--- a/query.go
+++ b/query.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/burningalchemist/sql_exporter/config"
 	"github.com/burningalchemist/sql_exporter/errors"
@@ -119,6 +120,13 @@ func (q *Query) Collect(ctx context.Context, conn *sql.DB, ch chan<- Metric) {
 
 // run executes the query on the provided database, in the provided context.
 func (q *Query) run(ctx context.Context, conn *sql.DB) (*sql.Rows, errors.WithContext) {
+	if slog.Default().Enabled(ctx, slog.LevelDebug) {
+		start := time.Now()
+		defer func() {
+			slog.Debug("Query execution time", "logContext", q.logContext, "duration", time.Since(start))
+		}()
+	}
+
 	if q.conn != nil && q.conn != conn {
 		panic(fmt.Sprintf("[%s] Expecting to always run on the same database handle", q.logContext))
 	}


### PR DESCRIPTION
This pull request includes changes to the `query.go` file to enhance the logging functionality and improve the monitoring of query execution times.

Logging enhancements:

* [`query.go`](diffhunk://#diff-66f9c6b00ef4ad1dbef1133865440121c8d03aec3333e8b6dd97ac3560b91ac7R8): Added the `time` package to the imports section to facilitate time tracking.
* [`query.go`](diffhunk://#diff-66f9c6b00ef4ad1dbef1133865440121c8d03aec3333e8b6dd97ac3560b91ac7R123-R129): Introduced a debug log to measure and log the execution time of queries if the debug level is enabled in the default logger. This includes capturing the start time before executing the query and logging the duration after the query completes.