### PR TITLE
feat(helm): Add path support for ingress in the helm chart

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: 0.17.0
 keywords:
   - exporter

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.0](https://img.shields.io/badge/AppVersion-0.17.0-informational?style=flat-square)
+![Version: 0.10.2](https://img.shields.io/badge/Version-0.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.0](https://img.shields.io/badge/AppVersion-0.17.0-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 
@@ -65,6 +65,7 @@ as an example.
 | ingress.annotations | object | `{}` | Ingress annotations |
 | ingress.ingressClassName | string | `""` | Ingress class name |
 | ingress.host | string | `""` | Ingress host |
+| ingress.path | string | `"/"` | Ingress path |
 | ingress.tls | object | `{"crt":"","enabled":false,"key":"","secretName":""}` | Ingress TLS, can be defined by cert secret, or by key and cert. |
 | ingress.tls.secretName | string | `""` | Ingress tls secret if already exists. |
 | ingress.tls.crt | string | `""` | Ingress tls.crt, required if you don't have secret name. |

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -25,7 +25,7 @@ spec:
   rules:
   - http:
       paths:
-        - path: /
+        - path: {{ .Values.ingress.path }}
           pathType: Prefix
           backend:
             service:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -34,6 +34,8 @@ ingress:
   ingressClassName: ""
   # -- Ingress host
   host: ""
+  # -- Ingress path
+  path: "/"
   # -- Ingress TLS, can be defined by cert secret, or by key and cert.
   tls:
     enabled: false


### PR DESCRIPTION
Some time ago, I wanted to add support for Ingress in SQL Exporter, but I was beaten to it in #640 :) However, after the introduction of Ingress support, I was missing just one thing – the ability to set the value of the path parameter. This PR adds that capability.