### PR TITLE
feat(helm): add support for initContainers on the chart

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.11.1
+version: 0.12
 appVersion: 0.17.1
 keywords:
   - exporter

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.12
+version: 0.12.0
 appVersion: 0.17.1
 keywords:
   - exporter

--- a/helm/README.md
+++ b/helm/README.md
@@ -71,6 +71,7 @@ as an example.
 | ingress.tls.crt | string | `""` | Ingress tls.crt, required if you don't have secret name. |
 | ingress.tls.key | string | `""` | Ingress tls.key, required if you don't have secret name. |
 | extraContainers | object | `{}` | Arbitrary sidecar containers list |
+| initContainers | object | `{}` | Arbitrary sidecar containers list for 1.29+ kubernetes |
 | serviceAccount.create | bool | `true` | Specifies whether a Service Account should be created, creates "sql-exporter" service account if true, unless overriden. Otherwise, set to `default` if false, and custom service account name is not provided. Check all the available parameters. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the Service Account |
 | livenessProbe.initialDelaySeconds | int | `5` |  |

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -47,6 +47,10 @@ spec:
         - name: {{ $v.name }}
           {{- toYaml $v.volume | nindent 10 }}
       {{- end }}
+{{- if .Values.initContainers }}
+      initContainers:
+{{ toYaml .Values.initContainers | nindent 8 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -47,6 +47,7 @@ ingress:
     # -- Ingress tls.key, required if you don't have secret name.
     key: ""
     # key: "{{- .Files.Get \"tls.key\" -}}"
+
 # -- Arbitrary sidecar containers list
 extraContainers: {}
 #   - name: your_sidecar
@@ -54,8 +55,10 @@ extraContainers: {}
 #     args:
 #     resources:
 #       requests:{}
+
 # -- Arbitrary sidecar containers list for 1.29+ kubernetes
 initContainers: {}
+
 serviceAccount:
   # -- Specifies whether a Service Account should be created, creates "sql-exporter" service account if true, unless
   # overriden. Otherwise, set to `default` if false, and custom service account name is not provided. Check all the

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -47,7 +47,6 @@ ingress:
     # -- Ingress tls.key, required if you don't have secret name.
     key: ""
     # key: "{{- .Files.Get \"tls.key\" -}}"
-
 # -- Arbitrary sidecar containers list
 extraContainers: {}
 #   - name: your_sidecar
@@ -55,6 +54,8 @@ extraContainers: {}
 #     args:
 #     resources:
 #       requests:{}
+# -- Arbitrary sidecar containers list for 1.29+ kubernetes
+initContainers: {}
 serviceAccount:
   # -- Specifies whether a Service Account should be created, creates "sql-exporter" service account if true, unless
   # overriden. Otherwise, set to `default` if false, and custom service account name is not provided. Check all the


### PR DESCRIPTION
Kubernetes 1.29+ now supports sidecars containers: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/

Add support `initContainers` as a field on the chart.