### PR TITLE
feat(helm): add support to relabelings in servicemonitor

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.12.0
+version: 0.12.1
 appVersion: 0.17.1
 keywords:
   - exporter

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.1](https://img.shields.io/badge/AppVersion-0.17.1-informational?style=flat-square)
+![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.17.1](https://img.shields.io/badge/AppVersion-0.17.1-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 
@@ -95,6 +95,7 @@ as an example.
 | serviceMonitor.interval | string | `"15s"` | ServiceMonitor interval |
 | serviceMonitor.path | string | `"/metrics"` | ServiceMonitor path |
 | serviceMonitor.metricRelabelings | object | `{}` | ServiceMonitor metric relabelings |
+| serviceMonitor.relabelings | object | `{}` | ServiceMonitor relabelings |
 | serviceMonitor.namespace | string | `nil` | ServiceMonitor namespace override (default is .Release.Namespace) |
 | serviceMonitor.scrapeTimeout | string | `nil` | ServiceMonitor scrape timeout |
 

--- a/helm/templates/servicemonitor.yaml
+++ b/helm/templates/servicemonitor.yaml
@@ -32,6 +32,10 @@ spec:
       metricRelabelings:
       {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
     {{- if .Values.serviceMonitor.namespace }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -115,6 +115,8 @@ serviceMonitor:
   # scrapeTimeout: 10s
   # -- ServiceMonitor metric relabelings
   metricRelabelings: {}
+  # -- ServiceMonitor relabelings
+  relabelings: {}
   # -- ServiceMonitor namespace override (default is .Release.Namespace)
   namespace: ~
 # Additional env variables


### PR DESCRIPTION
This adds support for the `relabelings` field in the `ServiceMonitor` spec. It’s needed to extract pod labels and attach them to metrics.

For example, scraping a pod label like `team` allows adding it as a metric label. This helps with things like routing alerts based on team ownership.

```
  relabelings:
  - action: replace
    sourceLabels:
    - __meta_kubernetes_pod_label_team
    targetLabel: team
```