### PR TITLE
build: update go version to 1.24+, remove toolchain directive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,8 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: ^1.20
+        go-version: ^1.24
+        check-latest: true
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,8 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: ^1.20
+        go-version: ^1.24
+        check-latest: true
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
 

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,6 @@
 go:
     cgo: false
-    version: 1.23
+    version: 1.24
 repository:
     path: github.com/burningalchemist/sql_exporter
 build:

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/burningalchemist/sql_exporter
 
 go 1.23.0
 
-toolchain go1.24.1
-
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.34.0
 	github.com/aws/aws-sdk-go-v2 v1.36.3


### PR DESCRIPTION
This pull request updates the Go version used across the project to ensure compatibility with the latest features and improvements. The changes affect the workflow configurations, project settings, and module dependencies.