### PR TITLE
feat: add -config.check flag for configuration validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ $ ./sql_exporter -help
 Usage of ./sql_exporter:
   -config.file string
       SQL Exporter configuration file path. (default "sql_exporter.yml")
+  -check-config
+      Check configuration and exit.
   -web.listen-address string
       Address to listen on for web interface and telemetry. (default ":9399")
   -web.metrics-path string

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ ./sql_exporter -help
 Usage of ./sql_exporter:
   -config.file string
       SQL Exporter configuration file path. (default "sql_exporter.yml")
-  -check-config
+  -config.check
       Check configuration and exit.
   -web.listen-address string
       Address to listen on for web interface and telemetry. (default ":9399")

--- a/cmd/sql_exporter/main.go
+++ b/cmd/sql_exporter/main.go
@@ -35,7 +35,7 @@ var (
 	enableReload  = flag.Bool("web.enable-reload", false, "Enable reload collector data handler")
 	webConfigFile = flag.String("web.config.file", "", "[EXPERIMENTAL] TLS/BasicAuth configuration file path")
 	configFile    = flag.String("config.file", "sql_exporter.yml", "SQL Exporter configuration file path")
-	checkConfig   = flag.Bool("check-config", false, "Check configuration and exit")
+	configCheck   = flag.Bool("config.check", false, "Check configuration and exit")
 	logFormat     = flag.String("log.format", "logfmt", "Set log output format")
 	logLevel      = flag.String("log.level", "info", "Set log level")
 	logFile       = flag.String("log.file", "", "Log file to write to, leave empty to write to stderr")
@@ -83,7 +83,7 @@ func main() {
 		*configFile = val
 	}
 
-	if *checkConfig {
+	if *configCheck {
 		slog.Info("Checking configuration file", "configFile", *configFile)
 		if _, err := cfg.Load(*configFile); err != nil {
 			slog.Error("Configuration check failed", "error", err)

--- a/cmd/sql_exporter/main.go
+++ b/cmd/sql_exporter/main.go
@@ -35,6 +35,7 @@ var (
 	enableReload  = flag.Bool("web.enable-reload", false, "Enable reload collector data handler")
 	webConfigFile = flag.String("web.config.file", "", "[EXPERIMENTAL] TLS/BasicAuth configuration file path")
 	configFile    = flag.String("config.file", "sql_exporter.yml", "SQL Exporter configuration file path")
+	checkConfig   = flag.Bool("check-config", false, "Check configuration and exit")
 	logFormat     = flag.String("log.format", "logfmt", "Set log output format")
 	logLevel      = flag.String("log.level", "info", "Set log level")
 	logFile       = flag.String("log.file", "", "Log file to write to, leave empty to write to stderr")
@@ -80,6 +81,16 @@ func main() {
 	// Override the config.file default with the SQLEXPORTER_CONFIG environment variable if set.
 	if val, ok := os.LookupEnv(cfg.EnvConfigFile); ok {
 		*configFile = val
+	}
+
+	if *checkConfig {
+		slog.Info("Checking configuration file", "configFile", *configFile)
+		if _, err := cfg.Load(*configFile); err != nil {
+			slog.Error("Configuration check failed", "error", err)
+			os.Exit(1)
+		}
+		slog.Info("Configuration check successful")
+		os.Exit(0)
 	}
 
 	slog.Warn("Starting SQL exporter", "versionInfo", version.Info(), "buildContext", version.BuildContext())


### PR DESCRIPTION
Introduce a new command-line flag to validate the configuration before starting the SQL exporter.

This Flag could be used to validate main configuration yaml and possible collector ones in a github-action pipeline before deployment