### PR TITLE
build: pin gha gh-release to v2.2.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       run: make crossbuild-checksum
 
     - name: Upload artifacts
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v2.2.2
       with:
         files: |
           .tarballs/*


### PR DESCRIPTION
This pull request updates the version of the GitHub Action used for releasing artifacts in the `.github/workflows/release.yml` file.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L47-R47): Updated the `softprops/action-gh-release` action from version `v2` to `v2.2.2` to ensure compatibility and access to the latest features and fixes.