### PR TITLE
fix: move NULL messages under Debug log level

### DIFF
--- a/query.go
+++ b/query.go
@@ -213,17 +213,17 @@ func (q *Query) scanRow(rows *sql.Rows, dest []any) (map[string]any, errors.With
 		switch q.columnTypes[column] {
 		case columnTypeKey:
 			if !dest[i].(*sql.NullString).Valid {
-				slog.Warn("Key column is NULL", "logContext", q.logContext, "column", column)
+				slog.Debug("Key column is NULL", "logContext", q.logContext, "column", column)
 			}
 			result[column] = *dest[i].(*sql.NullString)
 		case columnTypeTime:
 			if !dest[i].(*sql.NullTime).Valid {
-				slog.Warn("Time column is NULL", "logContext", q.logContext, "column", column)
+				slog.Debug("Time column is NULL", "logContext", q.logContext, "column", column)
 			}
 			result[column] = *dest[i].(*sql.NullTime)
 		case columnTypeValue:
 			if !dest[i].(*sql.NullFloat64).Valid {
-				slog.Warn("Value column is NULL", "logContext", q.logContext, "column", column)
+				slog.Debug("Value column is NULL", "logContext", q.logContext, "column", column)
 			}
 			result[column] = *dest[i].(*sql.NullFloat64)
 		}


### PR DESCRIPTION
This pull request includes a minor change to the logging level in the `scanRow` method of the `query.go` file. It adjusts the log level from `Warn` to `Debug` for cases where key, time, or value columns are `NULL`. This should reduce the amount of unnecessarily rendered logs.

* [`query.go`](diffhunk://#diff-66f9c6b00ef4ad1dbef1133865440121c8d03aec3333e8b6dd97ac3560b91ac7L216-R226): Changed the log level from `slog.Warn` to `slog.Debug` for better granularity when logging `NULL` values in key, time, and value columns within the `scanRow` method.