### PR TITLE
build(nfpm): fix paths for deb/rpm packages [skip ci]

### DIFF
--- a/packaging/conf/nfpm.yaml
+++ b/packaging/conf/nfpm.yaml
@@ -15,10 +15,10 @@ contents:
 - src: .build/linux-amd64/sql_exporter
   dst: /usr/bin/sql_exporter
 
-- src: ./examples/sql_exporter.yml
+- src: ./examples/mssql/sql_exporter.yml
   dst: /usr/share/sql_exporter/sql_exporter.yml
   type: config
-- src: ./examples/mssql_standard.collector.yml
+- src: ./examples/mssql/mssql_standard.collector.yml
   dst: /usr/share/sql_exporter/mssql_example.collector.yml
   type: config
 


### PR DESCRIPTION
This pull request updates the packaging configuration for the SQL Exporter to use the correct example and collector configuration files for MSSQL.