### PR TITLE
Bump up helm chart to 0.13.4

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.13.3
-appVersion: 0.18.4
+version: 0.13.4
+appVersion: 0.18.5
 keywords:
   - exporter
   - servicemonitor

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.13.3](https://img.shields.io/badge/Version-0.13.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.18.4](https://img.shields.io/badge/AppVersion-0.18.4-informational?style=flat-square)
+![Version: 0.13.4](https://img.shields.io/badge/Version-0.13.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.18.5](https://img.shields.io/badge/AppVersion-0.18.5-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 


### PR DESCRIPTION
This pull request updates the Helm chart for `sql-exporter` to a new version, reflecting an upgrade to the underlying application version as well. The changes ensure that both the chart metadata and documentation are consistent with the new release.

Version updates:

* Updated the Helm chart version from `0.13.3` to `0.13.4` and the application version from `0.18.4` to `0.18.5` in `Chart.yaml`.
* Updated the version badges in `README.md` to reflect the new chart and application versions.