### PR TITLE
Bump up helm chart to 0.13.5

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.13.4
-appVersion: 0.18.5
+version: 0.13.5
+appVersion: 0.18.6
 keywords:
   - exporter
   - servicemonitor

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.13.4](https://img.shields.io/badge/Version-0.13.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.18.5](https://img.shields.io/badge/AppVersion-0.18.5-informational?style=flat-square)
+![Version: 0.13.5](https://img.shields.io/badge/Version-0.13.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.18.6](https://img.shields.io/badge/AppVersion-0.18.6-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 


### PR DESCRIPTION
This pull request updates the Helm chart version and application version for the `sql-exporter` project. These changes ensure that the documentation and chart metadata reflect the latest release.

Version updates:

* Incremented the Helm chart version from `0.13.4` to `0.13.5` and the application version from `0.18.5` to `0.18.6` in `Chart.yaml` to match the new release.
* Updated the version badges in `README.md` to display the new chart and application versions for consistency with the latest release.