### PR TITLE
build: update to go v1.25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v6
       with:
-        go-version: '^1.24.0'
+        go-version: '^1.25.0'
         check-latest: true
       id: go
     - name: Check out code into the Go module directory

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '^1.24.0'
+        go-version: '^1.25.0'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v6
       with:
-        go-version: '^1.24.0'
+        go-version: '^1.25.0'
         check-latest: true
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,6 @@
 go:
     cgo: false
-    version: 1.24
+    version: 1.25
 repository:
     path: github.com/burningalchemist/sql_exporter
 build:


### PR DESCRIPTION
This pull request updates the project to use Go version 1.25 across all workflows and build configurations. This ensures consistency in the Go environment for building, releasing, and analyzing the codebase.

Go version updates:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L20-R20): Updated the Go version used in the build workflow from 1.24.0 to 1.25.0.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L19-R19): Updated the Go version used in the release workflow from 1.24.0 to 1.25.0.
* [`.github/workflows/codeql-analysis.yml`](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L40-R40): Updated the Go version used in the CodeQL analysis workflow from 1.24.0 to 1.25.0.
* [`.promu.yml`](diffhunk://#diff-76a63a7d40d9c5b7f57eed5b30dd49aaa623ad3d151a7846ffeca93f08db0eb8L3-R3): Updated the Go version specified for builds from 1.24 to 1.25.