### PR TITLE
Bump up helm chart to 0.14.1

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.14.0
-appVersion: 0.18.6
+version: 0.14.1
+appVersion: 0.19.0
 keywords:
   - exporter
   - servicemonitor

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.18.6](https://img.shields.io/badge/AppVersion-0.18.6-informational?style=flat-square)
+![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.19.0](https://img.shields.io/badge/AppVersion-0.19.0-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 


### PR DESCRIPTION
This pull request updates the Helm chart for `sql-exporter` to a new version and synchronizes the documentation and metadata to reflect the latest application release.

Version and app version updates:

* Bumped the chart version in `helm/Chart.yaml` from `0.14.0` to `0.14.1` and the `appVersion` from `0.18.6` to `0.19.0` to reflect the latest release.
* Updated version badges in `helm/README.md` to match the new chart and application versions.