### PR TITLE
Bump up helm chart to 0.14.2

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.14.1
-appVersion: 0.19.0
+version: 0.14.2
+appVersion: 0.19.1
 keywords:
   - exporter
   - servicemonitor

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.19.0](https://img.shields.io/badge/AppVersion-0.19.0-informational?style=flat-square)
+![Version: 0.14.2](https://img.shields.io/badge/Version-0.14.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.19.1](https://img.shields.io/badge/AppVersion-0.19.1-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 


### PR DESCRIPTION
This pull request updates the Helm chart for `sql-exporter` to a new patch version, reflecting an upgrade of both the chart and application versions.

Version updates:

* Bumped the chart version from `0.14.1` to `0.14.2` and the application version from `0.19.0` to `0.19.1` in `helm/Chart.yaml`.
* Updated the version badges in `helm/README.md` to match the new chart and application versions.