### PR TITLE
helm: include warmup_delay parameter

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -106,11 +106,12 @@ as an example.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| config | object | `{"global":{"max_connections":3,"max_idle_connections":3,"min_interval":"0s","scrape_error_drop_interval":"0s","scrape_timeout":"10s","scrape_timeout_offset":"500ms"}}` | SQL Exporter configuration, can be a dictionary, or a template yaml string. |
+| config | object | `{"global":{"max_connections":3,"max_idle_connections":3,"min_interval":"0s","scrape_error_drop_interval":"0s","scrape_timeout":"10s","scrape_timeout_offset":"500ms","warmup_delay":"0s"}}` | SQL Exporter configuration, can be a dictionary, or a template yaml string. |
 | config.global.scrape_timeout | string | `"10s"` | Scrape timeout |
 | config.global.scrape_timeout_offset | string | `"500ms"` | Scrape timeout offset. Must be strictly positive. |
 | config.global.scrape_error_drop_interval | string | `"0s"` | Interval between dropping scrape_errors_total metric: by default the metric is persistent. |
 | config.global.min_interval | string | `"0s"` | Minimum interval between collector runs. |
+| config.global.warmup_delay | string | `"0s"` | Delay between collector scrapes during the startup cache warmup. Disabled by default. |
 | config.global.max_connections | int | `3` | Number of open connections. |
 | config.global.max_idle_connections | int | `3` | Number of idle connections. |
 | target | object | `nil` | Check documentation. Mutually exclusive with `jobs`  |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -171,6 +171,8 @@ config:
     scrape_error_drop_interval: 0s
     # -- Minimum interval between collector runs.
     min_interval: 0s
+    # -- Delay between collector scrapes during the startup cache warmup. Disabled by default.
+    warmup_delay: 0s
     # -- Number of open connections.
     max_connections: 3
     # -- Number of idle connections.


### PR DESCRIPTION
This pull request adds support for configuring a `warmup_delay` parameter in the SQL Exporter Helm chart, allowing users to specify a delay between collector scrapes during the startup cache warmup. Documentation has been updated to reflect this new option.

Configuration changes:

* Added the `warmup_delay` option to the `config.global` section in `helm/values.yaml`, with documentation describing its purpose and default value.

Documentation updates:

* Updated the configuration table in `helm/README.md` to include the new `warmup_delay` option, clarifying its usage and default behavior.