### PR TITLE
Bump up helm chart to 0.17.4

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.17.3
-appVersion: 0.22.1
+version: 0.17.4
+appVersion: 0.22.2
 annotations:
   artifacthub.io/signKey: |
     fingerprint: 9F218BE64F503809BB829626B9024AEA76E9BCB3

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.17.2](https://img.shields.io/badge/Version-0.17.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.22.1](https://img.shields.io/badge/AppVersion-0.22.1-informational?style=flat-square)
+![Version: 0.17.4](https://img.shields.io/badge/Version-0.17.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.22.2](https://img.shields.io/badge/AppVersion-0.22.2-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 


### PR DESCRIPTION
This pull request updates the Helm chart for `sql-exporter` to the latest version. The version numbers in both the chart metadata and documentation have been incremented to reflect the new release.

Version updates:

* Bumped the chart `version` to `0.17.4` and `appVersion` to `0.22.2` in `helm/Chart.yaml` to release the latest changes.
* Updated the version badges in `helm/README.md` to match the new chart and app versions.