### PR TITLE
Fix crash during /reload from nil connection race condition

### DIFF
--- a/query.go
+++ b/query.go
@@ -125,6 +125,10 @@ func (q *Query) Collect(ctx context.Context, conn *sql.DB, ch chan<- Metric) {
 
 // run executes the query on the provided database, in the provided context.
 func (q *Query) run(ctx context.Context, conn *sql.DB) (*sql.Rows, errors.WithContext) {
+	if conn == nil {
+		return nil, errors.Errorf(q.logContext, "nil database connection")
+	}
+
 	if slog.Default().Enabled(ctx, slog.LevelDebug) {
 		start := time.Now()
 		defer func() {

--- a/target.go
+++ b/target.go
@@ -136,12 +136,13 @@ func (t *target) Collect(ctx context.Context, ch chan<- Metric) {
 	var wg sync.WaitGroup
 	// Don't bother with the collectors if target is down.
 	if targetUp {
+		conn := t.conn
 		wg.Add(len(t.collectors))
 		for _, c := range t.collectors {
 			// If using a single DB connection, collectors will likely run sequentially anyway. But we might have more.
 			go func(collector Collector) {
 				defer wg.Done()
-				collector.Collect(ctx, t.conn, ch)
+				collector.Collect(ctx, conn, ch)
 			}(c)
 		}
 	}


### PR DESCRIPTION
Fixes #970

Collectors were capturing t.conn directly in the goroutine closure, so if reload cleared the connection before the goroutine ran, it'd panic. Grabbing the connection value up front before spawning the goroutines avoids the race. Added a nil check in query.run() as a defensive measure too.