### PR TITLE
fix: introduce mutex to avoid nil deferences for reloads while scraping

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -54,6 +54,8 @@ type exporter struct {
 
 	ctx      context.Context
 	registry prometheus.Registerer
+
+	mu sync.RWMutex
 }
 
 // NewExporter returns a new Exporter with the provided config.
@@ -126,7 +128,10 @@ func (e *exporter) Gather() ([]*dto.MetricFamily, error) {
 	)
 
 	// Take a local snapshot to avoid mutating e.targets while collectors are running.
+	// We need to lock targets for the duration of the snapshot to ensure we don't miss any targets or include partially updated targets.
+	e.mu.RLock()
 	targets := e.filteredTargets()
+	e.mu.RUnlock()
 
 	if len(targets) == 0 {
 		return nil, errors.New("no targets found")
@@ -257,11 +262,17 @@ func (e *exporter) Config() *config.Config {
 }
 
 func (e *exporter) Targets() []Target {
+	// We need to lock targets for the duration of the snapshot to ensure we don't return partially updated targets.
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	return e.targets
 }
 
 // UpdateTarget implements Exporter.
 func (e *exporter) UpdateTarget(target []Target) {
+	// We need to lock targets for the duration of the update to ensure we don't return partially updated targets.
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	e.targets = target
 }
 

--- a/target.go
+++ b/target.go
@@ -49,6 +49,7 @@ type target struct {
 	logContext         string
 	enablePing         *bool
 
+	mu   sync.RWMutex
 	conn *sql.DB
 	// Last successful ping time
 	lastPingTime time.Time
@@ -159,6 +160,11 @@ func (t *target) Collect(ctx context.Context, ch chan<- Metric) {
 // the connection was never opened.
 func (t *target) Close() error {
 	var errs []error
+
+	// We need to lock here because if the target is being closed while a scrape is starting, they might both try to close the connection at the same time. Once we have a handle, sql.DB takes care of concurrency for us.
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	// Close prepared statements first — before the db handle they reference is gone.
 	for _, c := range t.collectors {
 		if err := c.Close(); err != nil {
@@ -183,6 +189,11 @@ func (t *target) ping(ctx context.Context) errors.WithContext {
 	// Create the DB handle, if necessary. It won't usually open an actual connection, so we'll need to ping
 	// afterwards. We cannot do this only once at creation time because the sql.Open() documentation says it "may" open
 	// an actual connection, so it "may" actually fail to open a handle to a DB that's initially down.
+
+	// We need to lock here because if multiple scrapes start at the same time when the target is down, they might all try to open a connection at the same time. Once we have a handle, sql.DB takes care of concurrency for us.
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	if t.conn == nil {
 		conn, err := OpenConnection(ctx, t.logContext, t.dsn, t.globalConfig.MaxConns,
 			t.globalConfig.MaxIdleConns, t.globalConfig.MaxConnLifetime)


### PR DESCRIPTION
Fixes #970 

This pull request introduces thread-safety improvements to the `exporter` and `target` types by adding mutex locks to protect shared resources. These changes ensure that concurrent access to critical sections, such as target and connection management, is properly synchronized, preventing race conditions and potential data corruption.

**Thread-safety improvements:**

* Added a `sync.RWMutex` (`mu`) to the `exporter` struct and wrapped accesses to the `targets` slice in read/write locks to prevent concurrent read/write issues. (`exporter.go`, [[1]](diffhunk://#diff-e4987a222ab3e846614998485952d8ee42288062a30929290cf3ea0e815d5ae1R57-R58) [[2]](diffhunk://#diff-e4987a222ab3e846614998485952d8ee42288062a30929290cf3ea0e815d5ae1R131-R134) [[3]](diffhunk://#diff-e4987a222ab3e846614998485952d8ee42288062a30929290cf3ea0e815d5ae1R265-R275)
* Added a `sync.RWMutex` (`mu`) to the `target` struct and used locks in `Close` and `ping` methods to ensure only one goroutine can modify or close the database connection at a time. (`target.go`, [[1]](diffhunk://#diff-f4674119325f2703efb10234e76685cc5343c09c768b57df25a0b3783e1609b0R52) [[2]](diffhunk://#diff-f4674119325f2703efb10234e76685cc5343c09c768b57df25a0b3783e1609b0R163-R167) [[3]](diffhunk://#diff-f4674119325f2703efb10234e76685cc5343c09c768b57df25a0b3783e1609b0R192-R196)