### PR TITLE
build: update to go v1.26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v6
       with:
-        go-version: '^1.25.0'
+        go-version: '^1.26.0'
         check-latest: true
       id: go
     - name: Check out code into the Go module directory

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '^1.25.0'
+        go-version: '^1.26.0'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v6
       with:
-        go-version: '^1.25.0'
+        go-version: '^1.26.0'
         check-latest: true
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,6 @@
 go:
     cgo: false
-    version: 1.25
+    version: 1.26
 repository:
     path: github.com/burningalchemist/sql_exporter
 build:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 GO     := go
 GOPATH ?= $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 PROMU  := $(GOPATH)/bin/promu
-PROMU_VERSION := v0.17.0
+PROMU_VERSION := v0.18.1
 YQ  := $(GOPATH)/bin/yq
 YQ_VERSION  := v4.52.4
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/burningalchemist/sql_exporter
 
-go 1.25.7
+go 1.26.0
 
 require (
 	cloud.google.com/go/secretmanager v1.20.0


### PR DESCRIPTION
This pull request updates the project to use Go 1.26.0 throughout the build, release, and analysis workflows, and also updates the `promu` tool version. These changes ensure compatibility with the latest Go features and improvements, and bring the build tooling up to date.

**Go version updates:**

* Updated the Go version to `1.26.0` in the `go.mod` file, `.promu.yml`, and all GitHub Actions workflows (`build.yml`, `release.yml`, and `codeql-analysis.yml`). [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3) [[2]](diffhunk://#diff-76a63a7d40d9c5b7f57eed5b30dd49aaa623ad3d151a7846ffeca93f08db0eb8L3-R3) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L20-R20) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L19-R19) [[5]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L40-R40)

**Build tooling update:**

* Updated the `promu` tool version from `v0.17.0` to `v0.18.1` in the `Makefile`.