### PR TITLE
fix: use modern golang functions (go fix)

### DIFF
--- a/cmd/sql_exporter/util.go
+++ b/cmd/sql_exporter/util.go
@@ -29,8 +29,8 @@ func giveBuf(buf *bytes.Buffer) {
 // (which is empty if no compression is enabled).
 func decorateWriter(request *http.Request, writer io.Writer) (w io.Writer, encoding string) {
 	header := request.Header.Get(acceptEncodingHeader)
-	parts := strings.Split(header, ",")
-	for _, part := range parts {
+	parts := strings.SplitSeq(header, ",")
+	for part := range parts {
 		part := strings.TrimSpace(part)
 		if part == "gzip" || strings.HasPrefix(part, "gzip;") {
 			return gzip.NewWriter(writer), "gzip"
@@ -41,10 +41,10 @@ func decorateWriter(request *http.Request, writer io.Writer) (w io.Writer, encod
 
 // LogFunc is an adapter to allow the use of any function as a promhttp.Logger. If f is a function, LogFunc(f) is a
 // promhttp.Logger that calls f.
-type LogFunc func(args ...interface{})
+type LogFunc func(args ...any)
 
 // Println implements promhttp.Logger.
-func (log LogFunc) Println(args ...interface{}) {
+func (log LogFunc) Println(args ...any) {
 	log(args)
 }
 

--- a/config/metric_config.go
+++ b/config/metric_config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -102,10 +103,8 @@ func (m *MetricConfig) validateKeyLabels() error {
 		if err := checkLabel(li, "metric", m.Name); err != nil {
 			return err
 		}
-		for _, lj := range m.KeyLabels[i+1:] {
-			if li == lj {
-				return fmt.Errorf("duplicate key label %q for metric %q", li, m.Name)
-			}
+		if slices.Contains(m.KeyLabels[i+1:], li) {
+			return fmt.Errorf("duplicate key label %q for metric %q", li, m.Name)
 		}
 		if m.ValueLabel == li {
 			return fmt.Errorf("duplicate label %q (defined in both key_labels and value_label) for metric %q", li, m.Name)

--- a/warmup.go
+++ b/warmup.go
@@ -57,12 +57,10 @@ func (w *Warmup) Run(targets []Target, delay time.Duration, timeout time.Duratio
 				}
 				ch := make(chan Metric, capMetricChan)
 				var cwg sync.WaitGroup
-				cwg.Add(1)
-				go func() {
-					defer cwg.Done()
+				cwg.Go(func() {
 					for range ch {
 					}
-				}()
+				})
 				c.Collect(ctx, tc.conn, ch)
 				close(ch)
 				cwg.Wait()


### PR DESCRIPTION
This pull request introduces several improvements and code modernizations across the codebase, focusing on simplifying code, improving type usage, and leveraging newer Go standard library features. The main areas affected are utility functions, type definitions, duplicate label checking logic, and goroutine management.

**Code Modernization and Type Improvements:**

* Replaced the use of `interface{}` with `any` in the `LogFunc` type and its method to align with modern Go conventions, making the code more idiomatic.

**Logic Simplification and Use of Standard Library:**

* Updated duplicate label checking in `MetricConfig.validateKeyLabels` to use `slices.Contains` instead of a manual loop, simplifying the logic and improving readability. [[1]](diffhunk://#diff-b302e39f38f857c8e3d9d38c2b7329c70ab2408d249f82987790af3dfd9cfd35R5) [[2]](diffhunk://#diff-b302e39f38f857c8e3d9d38c2b7329c70ab2408d249f82987790af3dfd9cfd35L105-L109)

**Utility and Concurrency Enhancements:**

* Changed the splitting of the `Accept-Encoding` header to use `strings.SplitSeq` (likely a custom or newer function) and fixed the iteration method for improved correctness and clarity in `decorateWriter`.
* Modernized goroutine management in the `Warmup.Run` method by replacing manual `sync.WaitGroup` management with the more concise `cwg.Go` pattern, reducing boilerplate and potential errors.