### PR TITLE
Bump up helm chart to 0.17.6

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.17.5
-appVersion: 0.22.3
+version: 0.17.6
+appVersion: 0.23.0
 annotations:
   artifacthub.io/signKey: |
     fingerprint: 9F218BE64F503809BB829626B9024AEA76E9BCB3

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.17.5](https://img.shields.io/badge/Version-0.17.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.22.3](https://img.shields.io/badge/AppVersion-0.22.3-informational?style=flat-square)
+![Version: 0.17.6](https://img.shields.io/badge/Version-0.17.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.23.0](https://img.shields.io/badge/AppVersion-0.23.0-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 


### PR DESCRIPTION
This pull request updates the Helm chart for `sql-exporter` to a new version, reflecting an upgrade to both the chart and application versions. No other changes are included.

- Version updates:
  * Bumped the Helm chart version from `0.17.5` to `0.17.6` and the application version from `0.22.3` to `0.23.0` in both `Chart.yaml` and the version badge in `README.md`. [[1]](diffhunk://#diff-ab3e9fcf0ffe762ed2805586f2e116f0c38db08c3b34d6ba2cfa90e871a1d918L5-R6) [[2]](diffhunk://#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16L3-R3)