### PR TITLE
refactor: use new() instead of protobuf helper function

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -16,8 +16,6 @@ import (
 	"github.com/burningalchemist/sql_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
-
-	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -178,8 +176,8 @@ func (e *exporter) Gather() ([]*dto.MetricFamily, error) {
 		dtoMetricFamily, ok := dtoMetricFamilies[metricDesc.Name()]
 		if !ok {
 			dtoMetricFamily = &dto.MetricFamily{}
-			dtoMetricFamily.Name = proto.String(metricDesc.Name())
-			dtoMetricFamily.Help = proto.String(metricDesc.Help())
+			dtoMetricFamily.Name = new(metricDesc.Name())
+			dtoMetricFamily.Help = new(metricDesc.Help())
 			switch {
 			case dtoMetric.Gauge != nil:
 				dtoMetricFamily.Type = dto.MetricType_GAUGE.Enum()

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/xo/dburl v0.24.2
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.20.0
-	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
@@ -168,6 +167,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401001100-f93e5f3e9f0f // indirect
 	google.golang.org/grpc v1.80.0 // indirect
+	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect

--- a/metric.go
+++ b/metric.go
@@ -10,7 +10,6 @@ import (
 	"github.com/burningalchemist/sql_exporter/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
-	"google.golang.org/protobuf/proto"
 )
 
 // MetricDesc is a descriptor for a family of metrics, sharing the same name, help, labes, type.
@@ -60,8 +59,8 @@ func NewMetricFamily(logContext string, mc *config.MetricConfig, constLabels []*
 
 	for k, v := range mc.StaticLabels {
 		sortedLabels = append(sortedLabels, &dto.LabelPair{
-			Name:  proto.String(k),
-			Value: proto.String(v),
+			Name:  new(k),
+			Value: new(v),
 		})
 	}
 	sort.Sort(labelPairSorter(sortedLabels))
@@ -232,9 +231,9 @@ func (m *constMetric) Write(out *dto.Metric) errors.WithContext {
 	out.Label = m.labelPairs
 	switch t := m.desc.ValueType(); t {
 	case prometheus.CounterValue:
-		out.Counter = &dto.Counter{Value: proto.Float64(m.val)}
+		out.Counter = &dto.Counter{Value: new(m.val)}
 	case prometheus.GaugeValue:
-		out.Gauge = &dto.Gauge{Value: proto.Float64(m.val)}
+		out.Gauge = &dto.Gauge{Value: new(m.val)}
 	default:
 		return errors.Errorf(m.desc.LogContext(), "encountered unknown type %v", t)
 	}
@@ -257,8 +256,8 @@ func makeLabelPairs(desc MetricDesc, labelValues []string) []*dto.LabelPair {
 	labelPairs := make([]*dto.LabelPair, 0, totalLen)
 	for i, label := range labels {
 		labelPairs = append(labelPairs, &dto.LabelPair{
-			Name:  proto.String(label),
-			Value: proto.String(labelValues[i]),
+			Name:  new(label),
+			Value: new(labelValues[i]),
 		})
 	}
 	labelPairs = append(labelPairs, constLabels...)
@@ -303,7 +302,7 @@ type timestampedMetric struct {
 
 func (m timestampedMetric) Write(pb *dto.Metric) errors.WithContext {
 	e := m.Metric.Write(pb)
-	pb.TimestampMs = proto.Int64(m.t.Unix()*1000 + int64(m.t.Nanosecond()/1000000))
+	pb.TimestampMs = new(m.t.Unix()*1000 + int64(m.t.Nanosecond()/1000000))
 	return e
 }
 

--- a/target.go
+++ b/target.go
@@ -14,7 +14,6 @@ import (
 	"github.com/burningalchemist/sql_exporter/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
-	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -79,8 +78,8 @@ func NewTarget(
 	constLabelPairs := make([]*dto.LabelPair, 0, len(constLabels))
 	for n, v := range constLabels {
 		constLabelPairs = append(constLabelPairs, &dto.LabelPair{
-			Name:  proto.String(n),
-			Value: proto.String(v),
+			Name:  new(n),
+			Value: new(v),
 		})
 	}
 	sort.Sort(labelPairSorter(constLabelPairs))


### PR DESCRIPTION
Hi,

this PR is a small refactor, as Go 1.26 now allows to use `new()` instead of requiring helper functions.
https://go.dev/doc/go1.26#language

BR, Peter