### PR TITLE
fix: use single yaml package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/sethvargo/go-envconfig"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // MaxInt32 defines the maximum value of allowed integers and serves to help us avoid overflow/wraparound issues.

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.20.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
 )
@@ -170,6 +169,7 @@ require (
 	google.golang.org/grpc v1.80.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect
 	k8s.io/api v0.36.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/xo/dburl v0.24.2
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.20.0
-	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
 )


### PR DESCRIPTION
Hi,

the project is currently using two versions of the same YAML package.
`gopkg.in/yaml.v3` is no longer maintained as of April 1, 2025.
`go.yaml.in/yaml/v3` is a fork created by the YAML Organization, which continues to maintain the project.

BR, Peter

