### PR TITLE
feat(helm): add resizePolicy and dnsConfig to pod spec

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.17.7
+version: 0.18.0
 appVersion: 0.24.0
 annotations:
   artifacthub.io/signKey: |

--- a/helm/README.md
+++ b/helm/README.md
@@ -64,6 +64,7 @@ See the [examples directory](../examples/) for complete configuration examples: 
 | commonAnnotations | object | `{}` | Common annotations to add to all the deployed resources |
 | commonLabels | object | `{}` | Common labels to add to all deployed resources |
 | createConfig | bool | `true` | Set to true to create a config as a part of the helm chart |
+| dnsConfig | object | `{}` | Pod DNS configuration (e.g. set ndots to reduce DNS lookup latency) |
 | extraContainers | object | `{}` | Arbitrary sidecar containers list |
 | extraManifests | list | `[]` | Arbitrary manifests list |
 | fullnameOverride | string | `""` | String to fully override "sql-exporter.fullname" |
@@ -89,6 +90,7 @@ See the [examples directory](../examples/) for complete configuration examples: 
 | podLabels | object | `{}` | Pod labels |
 | podSecurityContext | object | `{}` | Pod security context |
 | reloadEnabled | bool | `false` | Enable reload collector data handler (endpoint /reload) |
+| resizePolicy | list | `[]` | Container resize policy for in-place vertical scaling |
 | resources | object | `{}` | Resource limits and requests for the application controller pods |
 | service.annotations | object | `{}` | Service annotations |
 | service.labels | object | `{}` | Service labels |

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.17.7](https://img.shields.io/badge/Version-0.17.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -240,6 +240,10 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.resizePolicy }}
+          resizePolicy:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- with .Values.extraContainers }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -253,5 +257,9 @@ spec:
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.dnsConfig }}
+      dnsConfig:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -127,6 +127,17 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+# -- Container resize policy for in-place vertical scaling
+resizePolicy: []
+  # - resourceName: cpu
+  #   restartPolicy: NotRequired
+  # - resourceName: memory
+  #   restartPolicy: RestartContainer
+# -- Pod DNS configuration (e.g. set ndots to reduce DNS lookup latency)
+dnsConfig: {}
+  # options:
+  #   - name: ndots
+  #     value: "2"
 # -- Pod labels
 podLabels: {}
 # -- Pod annotations


### PR DESCRIPTION
## Summary

Adds two opt-in pod spec fields to the Helm chart:

- **[`resizePolicy`](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)** — container-level resize policy for in-place vertical scaling (Kubernetes 1.27+ with `InPlacePodVerticalScaling` feature gate). Lets operators avoid pod restarts on CPU/memory resize when desired.
- **[`dnsConfig`](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config)** — pod-level DNS configuration, commonly used to tune [`ndots`](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config-options) and cut down on unnecessary DNS lookups inside the cluster.

Both default to empty (`[]` / `{}`) and are rendered with `with` guards, so existing manifests are unchanged.

## Changes

- `helm/values.yaml`: add `resizePolicy` and `dnsConfig` with documentation comments and example values for CPU / memory / `ndots`.
- `helm/templates/deployment.yaml`: render `resizePolicy` under the container spec (after `resources`) and `dnsConfig` under the pod spec (after `tolerations`).
- `helm/README.md`: regenerated via `helm-docs`.

## Example

```yaml
resizePolicy:
  - resourceName: cpu
    restartPolicy: NotRequired
  - resourceName: memory
    restartPolicy: RestartContainer

dnsConfig:
  options:
    - name: ndots
      value: "2"
```

## Test plan

- [x] `helm lint helm/` passes
- [x] `helm template` with default values: neither `resizePolicy` nor `dnsConfig` is rendered (no regression)
- [x] `helm template` with the example above: `resizePolicy` placed at container scope, `dnsConfig.options[].name=ndots` at pod scope
- [x] `helm-docs` regenerated; new rows added to `helm/README.md`

Note: chart version intentionally not bumped — leaving it to a separate release bump PR, consistent with project history.