### PR TITLE
deps(dependabot): ignore aws sdk patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     - "dependencies"
     commit-message:
       prefix: "deps"
+    ignore:
+      - dependency-name: "github.com/aws/aws-sdk-go-v2*"
+        update-types:
+          - "version-update:semver-patch"


### PR DESCRIPTION
This pull request makes a small configuration change to the `.github/dependabot.yml` file to adjust dependency update behavior.

- Dependabot configuration:
  * Added an `ignore` rule to prevent Dependabot from creating pull requests for patch-level updates to any dependencies matching `github.com/aws/aws-sdk-go-v2*`.