### PR TITLE
Bump up helm chart to 0.18.1

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.18.0
-appVersion: 0.24.0
+version: 0.18.1
+appVersion: 0.24.1
 annotations:
   artifacthub.io/signKey: |
     fingerprint: 9F218BE64F503809BB829626B9024AEA76E9BCB3

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
+![Version: 0.18.1](https://img.shields.io/badge/Version-0.18.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.1](https://img.shields.io/badge/AppVersion-0.24.1-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 


### PR DESCRIPTION
This pull request updates the Helm chart for `sql-exporter` to reflect a new patch release. The version numbers have been incremented to indicate the latest changes, ensuring consistency across the chart metadata and documentation.

Version updates:

* Bumped `version` to `0.18.1` and `appVersion` to `0.24.1` in `helm/Chart.yaml` to reflect the new release.
* Updated version badges in `helm/README.md` to match the new chart and application versions.