### PR TITLE
build: fix wrong if conditional for build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    if: ${{ !startsWith(coalesce(github.event.pull_request.title, github.event.head_commit.message, ''), 'docs:') }}
+    if: ${{ !startsWith(github.event.pull_request.title || github.event.head_commit.message || '', 'docs:') }}
     name: Build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request makes a small update to the build workflow condition in `.github/workflows/build.yml`. The change switches from using the `coalesce` function to a simpler JavaScript-style `||` operator to determine the commit message or pull request title.