### PR TITLE
build: add govulncheck for released binary checks

### DIFF
--- a/.github/workflows/govulncheck-binary.yml
+++ b/.github/workflows/govulncheck-binary.yml
@@ -1,0 +1,52 @@
+name: Audit Released Binary (linux/amd64)
+
+on:
+  schedule:
+    - cron: "33 2 * * 1" # Every Monday at 02:33 UTC
+  workflow_dispatch:
+
+jobs:
+  govulncheck_binary:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Set up Go environment
+        uses: actions/setup-go@v6
+        with:
+          go-version: "stable"
+
+      - name: Install govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: |
+            README.md
+
+      - name: Fetch latest release binary
+        run: |
+          ASSET_NAME=$(gh release view --json assets -q '.assets[].name' | grep 'linux' | head -n 1)
+          if [ -z "$ASSET_NAME" ]; then echo "No binary found"; exit 1; fi
+          gh release download --pattern "$ASSET_NAME"
+          tar -xzf "$ASSET_NAME" --strip-components=1
+
+      - name: Run govulncheck on assets
+        id: run_vuln
+        run: |
+          govulncheck -mode=binary sql_exporter > govulncheck_output.txt
+
+      - name: Print the output to Summary
+        if: always() && steps.run_vuln.outcome != 'skipped'
+        run: |
+          echo "## 🛡️ govulncheck Scan Results" >> $GITHUB_STEP_SUMMARY
+          echo "Analysis completed for the released binary." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "<details><summary>Click to expand raw output</summary>" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```text' >> $GITHUB_STEP_SUMMARY
+          cat govulncheck_output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "</details>" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -7,10 +7,7 @@ on:
       - .github/workflows/govulncheck.yml
   push:
     branches:
-      - main
       - master
-  schedule:
-    - cron: "33 2 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request introduces a new workflow for automated binary vulnerability scanning and makes a minor adjustment to the existing source code scanning workflow. The main focus is on enhancing security by regularly auditing released binaries using `govulncheck`.

**Security automation:**

* Added a new workflow `.github/workflows/govulncheck-binary.yml` to automatically audit the released Linux/amd64 binary with `govulncheck` every Monday and on manual trigger. This workflow sets up the Go environment, installs `govulncheck`, fetches the latest release binary, runs the vulnerability check, and posts the results to the GitHub Actions summary.

**Workflow scheduling:**

* Removed the scheduled cron job from `.github/workflows/govulncheck.yml`, so the source code vulnerability check is no longer run on a schedule (it still runs on pushes to `master`).