### PR TITLE
build(govulncheck): exclude reviewed vulnerability IDs

### DIFF
--- a/.github/workflows/govulncheck-binary.yml
+++ b/.github/workflows/govulncheck-binary.yml
@@ -36,7 +36,17 @@ jobs:
       - name: Run govulncheck on assets
         id: run_vuln
         run: |
-          govulncheck -mode=binary sql_exporter > govulncheck_output.txt
+          govulncheck -mode=binary sql_exporter > govulncheck_output.txt || true
+
+          # GO-2026-5932 is for golang/x/crypto/openpgp that is unused
+          EXCLUDED_VULNS="GO-2026-5932"
+
+          if grep -E "GO-" govulncheck_output.txt | grep -q -E -v "$EXCLUDED_VULNS"; then
+            echo "New or unapproved vulnerabilities detected."
+            exit 1
+          else
+            echo "No unexpected vulnerabilities found."
+          fi
 
       - name: Print the output to Summary
         if: always() && steps.run_vuln.outcome != 'skipped'


### PR DESCRIPTION
This pull request updates the `govulncheck-binary.yml` workflow to improve vulnerability checking by allowing the exclusion of specific, known vulnerabilities from failing the workflow. The main change is that the workflow now filters out the known `GO-2026-5932` vulnerability (which is not relevant to the codebase), ensuring that only new or unapproved vulnerabilities will cause the workflow to fail.

**Vulnerability check improvements:**

* Modified the `govulncheck` step to always succeed, then added logic to exclude the known `GO-2026-5932` vulnerability from causing workflow failures, while still failing the workflow if any other vulnerabilities are detected (`.github/workflows/govulncheck-binary.yml`).