### PR TITLE
feat(chart): support deploymentStrategy, lifecycle, minReadySeconds, terminationGracePeriodSeconds

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.18.4
+version: 0.18.5
 appVersion: 0.24.4
 annotations:
   artifacthub.io/signKey: |

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.18.4](https://img.shields.io/badge/Version-0.18.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.4](https://img.shields.io/badge/AppVersion-0.24.4-informational?style=flat-square)
+![Version: 0.18.5](https://img.shields.io/badge/Version-0.18.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.4](https://img.shields.io/badge/AppVersion-0.24.4-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 
@@ -64,6 +64,7 @@ See the [examples directory](../examples/) for complete configuration examples: 
 | commonAnnotations | object | `{}` | Common annotations to add to all the deployed resources |
 | commonLabels | object | `{}` | Common labels to add to all deployed resources |
 | createConfig | bool | `true` | Set to true to create a config as a part of the helm chart |
+| deploymentStrategy | object | `{}` | Deployment update strategy, rendered verbatim under the Deployment's spec.strategy |
 | dnsConfig | object | `{}` | Pod DNS configuration (e.g. set ndots to reduce DNS lookup latency) |
 | extraContainers | object | `{}` | Arbitrary sidecar containers list |
 | extraManifests | list | `[]` | Arbitrary manifests list |
@@ -83,8 +84,10 @@ See the [examples directory](../examples/) for complete configuration examples: 
 | ingress.tls.key | string | `""` | Ingress tls.key, required if you don't have secret name. |
 | ingress.tls.secretName | string | `""` | Ingress tls secret if already exists. |
 | initContainers | object | `{}` | Arbitrary sidecar containers list for 1.29+ kubernetes |
+| lifecycle | object | `{}` | Container lifecycle hooks (e.g. preStop, to allow graceful deregistration during rolling updates) |
 | logFormat | string | `"logfmt"` | Set log format (logfmt if unset) |
 | logLevel | string | `"info"` | Set log level (info if unset) |
+| minReadySeconds | string | `""` | Minimum number of seconds for which a newly created pod should be ready, without any of its containers crashing, to be considered available (Deployment spec.minReadySeconds) |
 | nameOverride | string | `""` | Provide a name in place of `sql-exporter` |
 | podAnnotations | object | `{}` | Pod annotations |
 | podLabels | object | `{}` | Pod labels |
@@ -97,6 +100,7 @@ See the [examples directory](../examples/) for complete configuration examples: 
 | service.type | string | `"ClusterIP"` | Service type |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the Service Account |
 | serviceAccount.create | bool | `true` | Specifies whether a Service Account should be created, creates "sql-exporter" service account if true, unless overriden. Otherwise, set to `default` if false, and custom service account name is not provided. Check all the available parameters. |
+| terminationGracePeriodSeconds | string | `""` | Pod termination grace period in seconds (pod spec.terminationGracePeriodSeconds) |
 | webConfig | object | `{"basicAuth":{"bcryptCost":12,"enabled":false,"initFromSecret":{"enabled":false,"image":"httpd:alpine","imagePullPolicy":"IfNotPresent","secretKey":"password","secretName":""},"username":"prometheus","users":{}},"enabled":false,"template":"","tls":{"certFile":"tls.crt","certKey":"tls.crt","keyFile":"tls.key","keyKey":"tls.key","secretName":""}}` | Enable and configure Prometheus web config file support web-config.yml is automatically placed at /etc/sql_exporter/web-config.yml |
 | webConfig.basicAuth | object | `{"bcryptCost":12,"enabled":false,"initFromSecret":{"enabled":false,"image":"httpd:alpine","imagePullPolicy":"IfNotPresent","secretKey":"password","secretName":""},"username":"prometheus","users":{}}` | Basic authentication configuration for web-config |
 | webConfig.basicAuth.bcryptCost | int | `12` | Bcrypt cost used when hashing via initFromSecret |

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -8,6 +8,13 @@ metadata:
     {{- include "sql-exporter.annotations" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount | default 1 }}
+  {{- with .Values.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.minReadySeconds }}
+  minReadySeconds: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "sql-exporter.selectorLabels" . | nindent 6 }}
@@ -28,6 +35,9 @@ spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
     {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -242,6 +252,10 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.resizePolicy }}
           resizePolicy:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- with .Values.extraContainers }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -133,11 +133,26 @@ resizePolicy: []
   #   restartPolicy: NotRequired
   # - resourceName: memory
   #   restartPolicy: RestartContainer
+# -- Container lifecycle hooks (e.g. preStop, to allow graceful deregistration during rolling updates)
+lifecycle: {}
+  # preStop:
+  #   exec:
+  #     command: ["/bin/sh", "-c", "sleep 45"]
 # -- Pod DNS configuration (e.g. set ndots to reduce DNS lookup latency)
 dnsConfig: {}
   # options:
   #   - name: ndots
   #     value: "2"
+# -- Deployment update strategy, rendered verbatim under the Deployment's spec.strategy
+deploymentStrategy: {}
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 0
+# -- Minimum number of seconds for which a newly created pod should be ready, without any of its containers crashing, to be considered available (Deployment spec.minReadySeconds)
+minReadySeconds: ""
+# -- Pod termination grace period in seconds (pod spec.terminationGracePeriodSeconds)
+terminationGracePeriodSeconds: ""
 # -- Pod labels
 podLabels: {}
 # -- Pod annotations


### PR DESCRIPTION
> Bumps chart version to 0.18.5.

Fixes burningalchemist/sql_exporter#1053

## Summary

With `replicas: 1` (the common configuration for this exporter), a plain
rolling restart briefly drops the only pod backing the Service, causing
Prometheus scrape gaps on every redeploy. `spec.strategy`,
`spec.minReadySeconds`, container lifecycle hooks, and
`terminationGracePeriodSeconds` were not configurable, so there was no way
to avoid this from the chart.

This adds four new optional, passthrough values:

- `deploymentStrategy` → rendered verbatim under `spec.strategy` (e.g.
  `RollingUpdate` with `maxSurge: 1`, `maxUnavailable: 0` to guarantee a
  new pod is ready before the old one terminates)
- `minReadySeconds` → `spec.minReadySeconds` (hold the new pod as "not yet
  available" long enough for Prometheus to discover and scrape it)
- `lifecycle` → container `lifecycle` hooks (e.g. `preStop: sleep 45` to
  let in-flight scrapes finish and service endpoints propagate before
  SIGTERM)
- `terminationGracePeriodSeconds` → pod spec, sized to cover the `preStop`
  delay

Together these enable gapless rolling updates for single-replica
deployments: `maxUnavailable: 0` + a `preStop` sleep keeps the old pod
serving `/metrics` until the new pod is confirmed ready and endpoints have
propagated.

All four values default to unset/empty and are guarded with
`{{- with }}`, so existing releases render identically until explicitly
configured.

## Test plan

- [x] `helm lint helm/`
- [x] `ct lint --charts helm`
- [x] `helm template test helm/` diffed against master with the new
      values unset — identical output (only the chart-version
      label/checksum differ, from the version bump)
- [x] `helm template test helm/ -f <values with all four set>` — verified
      via `yq` that `spec.strategy`, `spec.minReadySeconds`,
      `spec.template.spec.terminationGracePeriodSeconds`, and
      `containers[0].lifecycle.preStop` render in the correct locations
