### PR TITLE
Bump up helm chart to 0.18.7

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.18.6
-appVersion: 0.24.4
+version: 0.18.7
+appVersion: 0.24.5
 annotations:
   artifacthub.io/signKey: |
     fingerprint: 9F218BE64F503809BB829626B9024AEA76E9BCB3


### PR DESCRIPTION
This pull request updates the Helm chart for `sql-exporter` to the latest versions. The changes are minor version bumps to keep dependencies current.

Version updates:

* Bumped the Helm chart `version` from `0.18.6` to `0.18.7` in `helm/Chart.yaml`.
* Updated the `appVersion` from `0.24.4` to `0.24.5` in `helm/Chart.yaml`.