### PR TITLE
fix: remap driver schemes to common variants if available

### DIFF
--- a/drivers_gen.go
+++ b/drivers_gen.go
@@ -30,6 +30,7 @@ var driverList = map[string][]string{
 	},
 	"custom": {
 		"github.com/mithrandie/csvq-driver",
+		"modernc.org/sqlite",
 	},
 }
 

--- a/drivers_remap.go
+++ b/drivers_remap.go
@@ -1,0 +1,68 @@
+package sql_exporter
+
+import (
+	"database/sql"
+	"slices"
+
+	"github.com/xo/dburl"
+)
+
+type overrideRule struct {
+	shadowedDriver string
+	claims         []string
+	fallback       []string
+}
+
+var overrideMap = map[string]overrideRule{
+	"sqlite": {
+		shadowedDriver: "sqlite3",
+		claims:         []string{"mq", "moderncsqlite", "modernsqlite"},
+		fallback:       []string{"sqlite", "sqlite3", "file"},
+	},
+	"pgx": {
+		shadowedDriver: "postgres",
+		claims:         []string{"pgx", "px"},
+		fallback:       []string{"pg", "pgsql", "postgres", "postgresql"},
+	},
+}
+
+// The purpose of this init call is to remap certain database driver schemes to their available implementations. This
+// ensures that when a user specifies a driver, it resolves to the correct implementation, even if multiple drivers
+// claim the same name.
+func init() {
+	available := sql.Drivers()
+
+	for targetDriver, rule := range overrideMap {
+		if !slices.Contains(available, targetDriver) {
+			continue
+		}
+
+		schemes := append([]string{targetDriver}, rule.claims...)
+
+		if !slices.Contains(available, rule.shadowedDriver) {
+			schemes = append(schemes, rule.fallback...)
+		}
+
+		var baseScheme *dburl.Scheme
+
+		// Unregister all aliases to clear possible conflicts
+		for _, alias := range schemes {
+			if old := dburl.Unregister(alias); old != nil && baseScheme == nil {
+				baseScheme = old
+			}
+		}
+
+		// Fallback to a default scheme if none was found
+		if baseScheme == nil {
+			baseScheme = &dburl.Scheme{}
+		}
+
+		// Re-register with the remapped drivers
+		dburl.Register(dburl.Scheme{
+			Driver:    targetDriver,
+			Generator: baseScheme.Generator,
+			Opaque:    baseScheme.Opaque,
+			Aliases:   schemes,
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/xo/dburl v0.24.2
 	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/sync v0.22.0
+	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
 )
@@ -169,7 +170,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect
-	k8s.io/api v0.36.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect


### PR DESCRIPTION
This pull request introduces improvements to database driver management and dependency updates. The main changes include adding a new driver to the custom driver list (pure go sqlite), implementing a remapping mechanism to resolve driver scheme conflicts, and updating Go module dependencies.

**Database driver enhancements:**

* Added `modernc.org/sqlite` to the list of custom drivers in `driverList` to support an alternative SQLite implementation.
* Introduced a new `drivers_remap.go` file that remaps database driver schemes to the correct implementations, resolving conflicts when multiple drivers claim the same scheme. This is achieved by unregistering conflicting aliases and re-registering them with the intended driver. This allows to select one of the overlapping drivers (such as `pgx` vs `lib/pq`) and yet avoid configuration changes.