### PR TITLE
deps: update go-ora driver to v3, minor changes

### DIFF
--- a/drivers.go
+++ b/drivers.go
@@ -8,7 +8,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "github.com/lib/pq"
 	_ "github.com/microsoft/go-mssqldb/azuread"
-	_ "github.com/sijms/go-ora/v2"
+	_ "github.com/sijms/go-ora/v3"
 	_ "github.com/snowflakedb/gosnowflake/v2"
 	_ "github.com/vertica/vertica-sql-go"
 )

--- a/drivers_gen.go
+++ b/drivers_gen.go
@@ -23,10 +23,12 @@ var driverList = map[string][]string{
 	},
 	"extra": {
 		"github.com/ClickHouse/clickhouse-go/v2",
+		"github.com/sijms/go-ora/v3",
 		"github.com/jackc/pgx/v5/stdlib",
+	},
+	"commercial": {
 		"github.com/snowflakedb/gosnowflake/v2",
 		"github.com/vertica/vertica-sql-go",
-		"github.com/sijms/go-ora/v2",
 	},
 	"custom": {
 		"github.com/mithrandie/csvq-driver",
@@ -63,10 +65,9 @@ func main() {
 
 	if key == "all" {
 		for k, list := range driverList {
-			if k == "custom" {
-				continue
+			if k == "minimal" || k == "extra" {
+				enabledDrivers = append(enabledDrivers, list...)
 			}
-			enabledDrivers = append(enabledDrivers, list...)
 		}
 	} else {
 		list, ok := driverList[key]

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/prometheus/common v0.70.1
 	github.com/prometheus/exporter-toolkit v0.17.1
 	github.com/sethvargo/go-envconfig v1.4.3
-	github.com/sijms/go-ora/v3 v3.0.1
+	github.com/sijms/go-ora/v3 v3.0.2-0.20260809153250-b6e6835f760b
 	github.com/snowflakedb/gosnowflake/v2 v2.1.0
 	github.com/vertica/vertica-sql-go v1.3.8
 	github.com/xo/dburl v0.24.2

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/prometheus/common v0.70.1
 	github.com/prometheus/exporter-toolkit v0.17.1
 	github.com/sethvargo/go-envconfig v1.4.3
-	github.com/sijms/go-ora/v2 v2.9.0
+	github.com/sijms/go-ora/v3 v3.0.1
 	github.com/snowflakedb/gosnowflake/v2 v2.1.0
 	github.com/vertica/vertica-sql-go v1.3.8
 	github.com/xo/dburl v0.24.2

--- a/go.sum
+++ b/go.sum
@@ -321,6 +321,8 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sijms/go-ora/v3 v3.0.1 h1:BU9j2MEji/hqprUFvY8DBbnfmVrt5TpVf4ngy9tqpWY=
 github.com/sijms/go-ora/v3 v3.0.1/go.mod h1:9NMI4/C/J9ExE/YNgQQlZXic2U1aCLHchJmmnDOK0jM=
+github.com/sijms/go-ora/v3 v3.0.2-0.20260809153250-b6e6835f760b h1:K+IoZtyCtDBktlrKS6EBxqnZcj1dxZ1KTfBokKcOyts=
+github.com/sijms/go-ora/v3 v3.0.2-0.20260809153250-b6e6835f760b/go.mod h1:9NMI4/C/J9ExE/YNgQQlZXic2U1aCLHchJmmnDOK0jM=
 github.com/snowflakedb/gosnowflake/v2 v2.1.0 h1:rfjs6NAMnbLKCBYlOarqQX/UKgQVrXi43TZNHCP5/jw=
 github.com/snowflakedb/gosnowflake/v2 v2.1.0/go.mod h1:c0hIqJ/dxgaMl7g1o8n4Ca3Mf5YCiiVx9igio/PNqC8=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ github.com/sethvargo/go-envconfig v1.4.3 h1:9RJrW9aiy3SJVRJ1svntpZvBw3ghj941u/Bs
 github.com/sethvargo/go-envconfig v1.4.3/go.mod h1:ebe6rgj7KzrRZPzDXU4W6WZWDEirQwvcgmS0bmC3Sjg=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
-github.com/sijms/go-ora/v2 v2.9.0 h1:+iQbUeTeCOFMb5BsOMgUhV8KWyrv9yjKpcK4x7+MFrg=
-github.com/sijms/go-ora/v2 v2.9.0/go.mod h1:QgFInVi3ZWyqAiJwzBQA+nbKYKH77tdp1PYoCqhR2dU=
+github.com/sijms/go-ora/v3 v3.0.1 h1:BU9j2MEji/hqprUFvY8DBbnfmVrt5TpVf4ngy9tqpWY=
+github.com/sijms/go-ora/v3 v3.0.1/go.mod h1:9NMI4/C/J9ExE/YNgQQlZXic2U1aCLHchJmmnDOK0jM=
 github.com/snowflakedb/gosnowflake/v2 v2.1.0 h1:rfjs6NAMnbLKCBYlOarqQX/UKgQVrXi43TZNHCP5/jw=
 github.com/snowflakedb/gosnowflake/v2 v2.1.0/go.mod h1:c0hIqJ/dxgaMl7g1o8n4Ca3Mf5YCiiVx9igio/PNqC8=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,6 @@ github.com/sethvargo/go-envconfig v1.4.3 h1:9RJrW9aiy3SJVRJ1svntpZvBw3ghj941u/Bs
 github.com/sethvargo/go-envconfig v1.4.3/go.mod h1:ebe6rgj7KzrRZPzDXU4W6WZWDEirQwvcgmS0bmC3Sjg=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
-github.com/sijms/go-ora/v3 v3.0.1 h1:BU9j2MEji/hqprUFvY8DBbnfmVrt5TpVf4ngy9tqpWY=
-github.com/sijms/go-ora/v3 v3.0.1/go.mod h1:9NMI4/C/J9ExE/YNgQQlZXic2U1aCLHchJmmnDOK0jM=
 github.com/sijms/go-ora/v3 v3.0.2-0.20260809153250-b6e6835f760b h1:K+IoZtyCtDBktlrKS6EBxqnZcj1dxZ1KTfBokKcOyts=
 github.com/sijms/go-ora/v3 v3.0.2-0.20260809153250-b6e6835f760b/go.mod h1:9NMI4/C/J9ExE/YNgQQlZXic2U1aCLHchJmmnDOK0jM=
 github.com/snowflakedb/gosnowflake/v2 v2.1.0 h1:rfjs6NAMnbLKCBYlOarqQX/UKgQVrXi43TZNHCP5/jw=


### PR DESCRIPTION
This pull request updates the Oracle database driver dependency from version 2 to version 3 and adjusts the driver registration and categorization accordingly. The main focus is to ensure compatibility with the latest version of `go-ora` and to update how drivers are grouped and enabled in the codebase.

Dependency updates:

* Updated the Oracle driver from `github.com/sijms/go-ora/v2` to `github.com/sijms/go-ora/v3` in both `go.mod` and the import statements in `drivers.go`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L23-R23) [[2]](diffhunk://#diff-b944ad3be6a3b406f12725c5d8d44c40e98d11e44cec754caa3516f98cac9335L11-R11)

Driver categorization and registration:

* Changed the driver grouping in `drivers_gen.go` by moving `github.com/sijms/go-ora/v3` to the `"extra"` category and removing the old v2 reference. Also, introduced a new `"commercial"` category for other drivers.
* Modified the logic for enabling drivers when the `"all"` key is specified, so only drivers in the `"minimal"` and `"extra"` categories are included, excluding `"custom"` and the new `"commercial"` group.