### PR TITLE
revert: update go-ora driver to v3

### DIFF
--- a/drivers.go
+++ b/drivers.go
@@ -8,7 +8,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "github.com/lib/pq"
 	_ "github.com/microsoft/go-mssqldb/azuread"
-	_ "github.com/sijms/go-ora/v3"
+	_ "github.com/sijms/go-ora/v2"
 	_ "github.com/snowflakedb/gosnowflake/v2"
 	_ "github.com/vertica/vertica-sql-go"
 )

--- a/drivers_gen.go
+++ b/drivers_gen.go
@@ -23,7 +23,7 @@ var driverList = map[string][]string{
 	},
 	"extra": {
 		"github.com/ClickHouse/clickhouse-go/v2",
-		"github.com/sijms/go-ora/v3",
+		"github.com/sijms/go-ora/v2",
 		"github.com/jackc/pgx/v5/stdlib",
 	},
 	"commercial": {

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/prometheus/common v0.70.1
 	github.com/prometheus/exporter-toolkit v0.19.0
 	github.com/sethvargo/go-envconfig v1.4.3
-	github.com/sijms/go-ora/v3 v3.0.2-0.20260809153250-b6e6835f760b
+	github.com/sijms/go-ora/v2 v2.9.0
 	github.com/snowflakedb/gosnowflake/v2 v2.1.0
 	github.com/vertica/vertica-sql-go v1.3.8
 	github.com/xo/dburl v0.24.2

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/sethvargo/go-envconfig v1.4.3 h1:9RJrW9aiy3SJVRJ1svntpZvBw3ghj941u/Bs
 github.com/sethvargo/go-envconfig v1.4.3/go.mod h1:ebe6rgj7KzrRZPzDXU4W6WZWDEirQwvcgmS0bmC3Sjg=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
-github.com/sijms/go-ora/v3 v3.0.2-0.20260809153250-b6e6835f760b h1:K+IoZtyCtDBktlrKS6EBxqnZcj1dxZ1KTfBokKcOyts=
-github.com/sijms/go-ora/v3 v3.0.2-0.20260809153250-b6e6835f760b/go.mod h1:9NMI4/C/J9ExE/YNgQQlZXic2U1aCLHchJmmnDOK0jM=
+github.com/sijms/go-ora/v2 v2.9.0 h1:+iQbUeTeCOFMb5BsOMgUhV8KWyrv9yjKpcK4x7+MFrg=
+github.com/sijms/go-ora/v2 v2.9.0/go.mod h1:QgFInVi3ZWyqAiJwzBQA+nbKYKH77tdp1PYoCqhR2dU=
 github.com/snowflakedb/gosnowflake/v2 v2.1.0 h1:rfjs6NAMnbLKCBYlOarqQX/UKgQVrXi43TZNHCP5/jw=
 github.com/snowflakedb/gosnowflake/v2 v2.1.0/go.mod h1:c0hIqJ/dxgaMl7g1o8n4Ca3Mf5YCiiVx9igio/PNqC8=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=


### PR DESCRIPTION
Reverts #1064 

This pull request downgrades the `go-ora` Oracle database driver dependency from version 3 to version 2 across the codebase. The most important changes are:

Dependency updates:

* Changed the import in `drivers.go` to use `github.com/sijms/go-ora/v2` instead of `v3`.
* Updated the required module in `go.mod` to `github.com/sijms/go-ora/v2 v2.9.0`.

Driver registration:

* Updated the driver registration in `drivers_gen.go` to reference `go-ora/v2` instead of `v3`.


Regressions:

- https://github.com/sijms/go-ora/issues/738
- https://github.com/sijms/go-ora/issues/730