### PR TITLE
Bump up helm chart to 0.18.9

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sql-exporter
 description: Database-agnostic SQL exporter for Prometheus
 type: application
-version: 0.18.8
-appVersion: 0.24.6
+version: 0.18.9
+appVersion: 0.24.7
 annotations:
   artifacthub.io/signKey: |
     fingerprint: 9F218BE64F503809BB829626B9024AEA76E9BCB3

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,6 @@
 # sql-exporter
 
-![Version: 0.18.8](https://img.shields.io/badge/Version-0.18.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.6](https://img.shields.io/badge/AppVersion-0.24.6-informational?style=flat-square)
+![Version: 0.18.9](https://img.shields.io/badge/Version-0.18.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.7](https://img.shields.io/badge/AppVersion-0.24.7-informational?style=flat-square)
 
 Database-agnostic SQL exporter for Prometheus
 


### PR DESCRIPTION
This pull request updates the Helm chart for `sql-exporter` to a new version. The changes are primarily version bumps to both the chart and application, ensuring that documentation and metadata stay in sync.

Version updates:

* Bumped the Helm chart version from `0.18.8` to `0.18.9` and the application version from `0.24.6` to `0.24.7` in `helm/Chart.yaml` to reflect the latest release.
* Updated the version badges in `helm/README.md` to match the new chart and application versions.